### PR TITLE
chore: backend .gitignore에 docs/ 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -21,6 +21,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+docs/
 
 # Django
 local_settings.py


### PR DESCRIPTION
### 변경 내용
- backend `.gitignore`에 `docs/` 누락되어 있어 추가

### 목적
- 문서 파일이 Git에 추적되지 않도록 정리