### PR TITLE
feat: 파트너 대시보드와 고객 상세 흐름을 정리하고 디자이너 진단 카드 UI를 개선

### DIFF
--- a/backend/templates/admin/customer_detail.html
+++ b/backend/templates/admin/customer_detail.html
@@ -6,40 +6,77 @@
 {% block hero_content %}
 <div style="max-width: 1200px; margin: 0 auto; width: 100%; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap;">
   <h2 class="hero-title" style="margin-bottom: 0; font-size: 24px;">고객 <span>스타일 분석 정보</span></h2>
-  <p class="section-copy" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">고객님이 등록하신 스타일 취향 및 설문 상세 데이터입니다.</p>
+  <p class="section-copy" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">고객 설문, 디자이너 진단 카드, 재분석 흐름을 한 화면에서 확인할 수 있습니다.</p>
 </div>
 {% endblock %}
 
 {% block content %}
 <style>
-  .detail-card { 
-    max-width: 800px; 
-    margin: 0 auto; 
-    padding: 40px 32px 32px !important; 
-    border-radius: 24px !important; 
-    position: relative; /* 버튼 배치를 위한 기준점 */
+  .detail-card {
+    max-width: 920px;
+    margin: 0 auto;
+    padding: 40px 32px 32px !important;
+    border-radius: 24px !important;
+    position: relative;
   }
-  .info-group { margin-bottom: 32px; border-bottom: 1.5px solid var(--line); padding-bottom: 24px; }
-  .info-group:last-child { border-bottom: none; }
-  .info-label { font-size: 13px; font-weight: 700; color: var(--text-secondary); margin-bottom: 12px; display: block; }
-  .survey-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
-  .survey-item { background: var(--bg-light); padding: 16px; border-radius: 12px; }
-  .survey-tag { font-size: 12px; color: var(--text-secondary); margin-bottom: 4px; display: block; }
-  .survey-value { font-size: 16px; font-weight: 700; color: var(--bg-dark); }
-  
-  /* 개선된 대시보드 돌아가기 버튼 스타일 */
+
+  .info-group {
+    margin-bottom: 32px;
+    border-bottom: 1.5px solid var(--line);
+    padding-bottom: 24px;
+  }
+
+  .info-group:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+  }
+
+  .info-label {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+    display: block;
+  }
+
+  .survey-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+
+  .survey-item {
+    background: var(--bg-light);
+    padding: 16px;
+    border-radius: 12px;
+  }
+
+  .survey-tag {
+    font-size: 12px;
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+    display: block;
+  }
+
+  .survey-value {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--bg-dark);
+  }
+
   .back-btn-container {
     position: absolute;
     top: 24px;
     right: 24px;
   }
-  .back-btn { 
-    display: inline-flex; 
-    align-items: center; 
-    gap: 6px; 
-    color: var(--text-secondary); 
-    text-decoration: none; 
-    font-size: 13px; 
+
+  .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 13px;
     font-weight: 600;
     padding: 8px 16px;
     border-radius: 10px;
@@ -47,26 +84,448 @@
     background: #fff;
     transition: all 0.2s ease;
   }
-  .back-btn:hover { 
-    color: var(--bg-dark); 
+
+  .back-btn:hover {
+    color: var(--bg-dark);
     border-color: var(--bg-dark);
     background: #fcfcfc;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  }
+
+  .action-strip {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+
+  .action-copy {
+    flex: 1;
+    min-width: 240px;
+  }
+
+  .action-copy p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .retry-hint {
+    margin-top: 12px;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .preview-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin-top: 16px;
+  }
+
+  .preview-card {
+    padding: 16px;
+    border-radius: 14px;
+    background: var(--bg-light);
+    border: 1px solid var(--line);
+  }
+
+  .preview-card strong {
+    display: block;
+    margin-bottom: 8px;
+    color: var(--bg-dark);
+  }
+
+  .retry-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(12, 10, 7, 0.56);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    z-index: 1200;
+  }
+
+  .retry-modal.is-hidden {
+    display: none;
+  }
+
+  .retry-modal-card {
+    width: min(520px, 100%);
+    background: #fff;
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.16);
+  }
+
+  .retry-option-list {
+    display: grid;
+    gap: 12px;
+    margin-top: 20px;
+  }
+
+  .retry-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 18px;
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    background: #fafafa;
+  }
+
+  .retry-option strong {
+    display: block;
+    color: var(--bg-dark);
+    margin-bottom: 6px;
+  }
+
+  .retry-option p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  .retry-option .btn {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .retry-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 20px;
+  }
+
+  .retry-status {
+    margin-top: 16px;
+    padding: 12px 14px;
+    border-radius: 12px;
+    font-size: 13px;
+    line-height: 1.5;
+    background: rgba(0, 0, 0, 0.04);
+    color: var(--text-primary);
+  }
+
+  .retry-status.is-hidden {
+    display: none;
+  }
+
+  .diagnosis-shell {
+    display: grid;
+    gap: 16px;
+  }
+
+  .diagnosis-shell.is-collapsed .diagnosis-meta,
+  .diagnosis-shell.is-collapsed .diagnosis-help,
+  .diagnosis-shell.is-collapsed .diagnosis-editor-block {
+    display: none;
+  }
+
+  .diagnosis-copy {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .diagnosis-meta {
+    padding: 16px 18px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(12, 10, 7, 0.04), rgba(12, 10, 7, 0.02));
+    border: 1px solid rgba(12, 10, 7, 0.08);
+  }
+
+  .diagnosis-meta strong {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--bg-dark);
+  }
+
+  .diagnosis-meta p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  .diagnosis-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+  }
+
+  .diagnosis-item {
+    display: grid;
+    gap: 14px;
+    border: 1px solid rgba(12, 10, 7, 0.08);
+  }
+
+  .diagnosis-item.is-wide {
+    grid-column: 1 / -1;
+  }
+
+  .diagnosis-item.is-filled {
+    border-color: rgba(12, 10, 7, 0.16);
+    box-shadow: 0 10px 26px rgba(12, 10, 7, 0.06);
+  }
+
+  .diagnosis-item-head {
+    display: grid;
+    gap: 8px;
+  }
+
+  .diagnosis-value-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .diagnosis-value {
+    line-height: 1.5;
+  }
+
+  .diagnosis-value.is-empty {
+    color: var(--text-secondary);
+  }
+
+  .diagnosis-edit-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: rgba(12, 10, 7, 0.06);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+
+  .diagnosis-help {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-secondary);
+    margin: 0;
+  }
+
+  .diagnosis-selection-list {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    min-height: 28px;
+  }
+
+  .diagnosis-selection-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(12, 10, 7, 0.12);
+    background: #fff;
+    color: var(--bg-dark);
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .diagnosis-selection-pill.is-empty {
+    border-style: dashed;
+    color: var(--text-secondary);
+    background: transparent;
+  }
+
+  .diagnosis-note-preview {
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--bg-dark);
+    white-space: pre-line;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .diagnosis-note-preview.is-empty {
+    color: var(--text-secondary);
+  }
+
+  .diagnosis-chip-group {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  .diagnosis-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 42px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: #fff;
+    color: var(--text-primary);
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+
+  .diagnosis-chip:hover {
+    border-color: rgba(12, 10, 7, 0.28);
+    transform: translateY(-1px);
+  }
+
+  .diagnosis-chip.is-selected {
+    background: var(--bg-dark);
+    color: #fff;
+    border-color: var(--bg-dark);
+    box-shadow: 0 10px 24px rgba(12, 10, 7, 0.16);
+  }
+
+  .diagnosis-chip.is-selected.multi {
+    background: rgba(12, 10, 7, 0.92);
+  }
+
+  .diagnosis-textarea {
+    min-height: 128px;
+    resize: vertical;
+  }
+
+  .diagnosis-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .diagnosis-actions-left {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .diagnosis-actions-right {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .diagnosis-status {
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .diagnosis-status.is-success {
+    color: #197754;
+    font-weight: 700;
+  }
+
+  .diagnosis-status.is-muted {
+    color: var(--text-secondary);
+  }
+
+  @media (max-width: 640px) {
+    .detail-card {
+      padding: 28px 20px 24px !important;
+    }
+
+    .survey-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .diagnosis-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .diagnosis-item.is-wide {
+      grid-column: auto;
+    }
+
+    .back-btn-container {
+      position: static;
+      margin-bottom: 20px;
+    }
+
+    .retry-option {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .diagnosis-actions {
+      align-items: stretch;
+    }
+
+    .diagnosis-actions-left {
+      width: 100%;
+    }
+
+    .diagnosis-actions-right {
+      width: 100%;
+      justify-content: space-between;
+    }
   }
 </style>
 
 <div class="customer-layout" style="display: block;">
   <div class="panel detail-card">
-    <!-- 박스 안쪽 우측 상단에 배치 -->
     <div class="back-btn-container">
-      <a href="{% url 'partner_staff_dashboard' %}" class="back-btn">
+      <a href="{% if request.session.designer_id %}{% url 'partner_staff_dashboard' %}{% else %}{% url 'partner_dashboard' %}{% endif %}" class="back-btn">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
         대시보드
       </a>
     </div>
 
     <div id="detailContent">
-      <div style="text-align: center; padding: 60px; opacity: 0.5;">데이터를 불러오는 중...</div>
+      <div style="text-align: center; padding: 60px; opacity: 0.5;">데이터를 불러오는 중입니다...</div>
+    </div>
+  </div>
+</div>
+
+<div id="retryChoiceModal" class="retry-modal is-hidden" aria-hidden="true">
+  <div class="retry-modal-card">
+    <h3 class="section-title" style="font-size: 22px; margin-bottom: 8px;">재분석 방식 선택</h3>
+    <p class="section-copy" style="font-size: 14px; margin-bottom: 0;">기존 취향을 유지할지, 취향을 다시 선택할지 먼저 정할 수 있습니다.</p>
+
+    <div class="retry-option-list">
+      <div class="retry-option">
+        <div>
+          <strong>기존 취향 유지</strong>
+          <p>저장된 취향 데이터를 그대로 사용해 현재 고객 결과를 다시 추천합니다.</p>
+        </div>
+        <button id="retryKeepPreferenceBtn" class="btn btn-primary" style="height: 44px; min-width: 148px; padding: 0 24px;">바로 재분석</button>
+      </div>
+
+      <div class="retry-option">
+        <div>
+          <strong>취향 다시 선택</strong>
+          <p>취향 설문을 다시 받고 이후 추천 생성 흐름으로 이어집니다.</p>
+        </div>
+        <button id="retryChooseAgainBtn" class="btn btn-dark" style="height: 44px; min-width: 148px; padding: 0 24px;">설문 다시 선택</button>
+      </div>
+    </div>
+
+    <div id="retryStatusMessage" class="retry-status is-hidden"></div>
+
+    <div class="retry-modal-actions">
+      <button type="button" class="btn btn-dark" style="height: 42px; padding: 0 20px;" onclick="hideRetryChoice()">닫기</button>
     </div>
   </div>
 </div>
@@ -74,46 +533,640 @@
 
 {% block page_scripts %}
 <script>
-  (async function() {
+  (function () {
     const clientId = "{{ client_id }}";
     const detailContent = document.getElementById('detailContent');
+    const retryChoiceModal = document.getElementById('retryChoiceModal');
+    const retryKeepPreferenceBtn = document.getElementById('retryKeepPreferenceBtn');
+    const retryChooseAgainBtn = document.getElementById('retryChooseAgainBtn');
+    const retryStatusMessage = document.getElementById('retryStatusMessage');
+    const diagnosisStorageKey = `mirrai-designer-diagnosis-${clientId}`;
 
-    try {
-      // 기존 API 활용 (상세 정보 가져오기)
-      const response = await fetch(`/api/v1/customers/${clientId}/`);
-      const data = await response.json();
-      const customer = data.data || data;
+    let currentCustomer = null;
+    let latestRetryPreviewHtml = '';
+    let diagnosisEditorCollapsed = false;
 
-      if (!customer) throw new Error('Customer not found');
+    const diagnosisOptionGroups = {
+      hairTexture: [
+        { value: 'fine', label: '가는 모발 (L)' },
+        { value: 'medium', label: '보통 모발 (M)' },
+        { value: 'coarse', label: '굵은 모발 (H)' }
+      ],
+      damageLevel: [
+        { value: 'level1', label: '건강모 (Lv.1)' },
+        { value: 'level2', label: '약손상 (Lv.2)' },
+        { value: 'level3', label: '손상모 (Lv.3)' },
+        { value: 'level4', label: '극손상 (Lv.4)' }
+      ],
+      specialNotes: [
+        { value: 'bleach_history', label: '탈색 이력' },
+        { value: 'black_red_cover', label: '블랙/레드 덮음' },
+        { value: 'natural_curl', label: '곱슬기 있음' },
+        { value: 'self_coloring', label: '셀프 염색' },
+        { value: 'head_shape_density', label: '두상/모량 특이사항' }
+      ]
+    };
 
-      // 템플릿 렌더링
+    function escapeHtml(value) {
+      return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function formatDate(value) {
+      if (!value) {
+        return '기록 없음';
+      }
+
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) {
+        return '기록 없음';
+      }
+
+      return date.toLocaleDateString();
+    }
+
+    function hasSurveyData(customer) {
+      return Boolean(customer && customer.survey);
+    }
+
+    function hasFaceAnalysis(customer) {
+      return Boolean(customer && Array.isArray(customer.face_analyses) && customer.face_analyses.length > 0);
+    }
+
+    function defaultDiagnosisState() {
+      return {
+        hairTexture: '',
+        damageLevel: '',
+        specialNotes: [],
+        specialMemo: ''
+      };
+    }
+
+    function normalizeDiagnosisState(state) {
+      const fallback = defaultDiagnosisState();
+      const nextState = Object.assign({}, fallback, state || {});
+      nextState.specialNotes = Array.isArray(nextState.specialNotes) ? nextState.specialNotes : [];
+      nextState.specialMemo = String(nextState.specialMemo || '');
+      return nextState;
+    }
+
+    function hasDiagnosisContent(state) {
+      const diagnosisState = normalizeDiagnosisState(state);
+      return Boolean(
+        diagnosisState.hairTexture
+        || diagnosisState.damageLevel
+        || diagnosisState.specialNotes.length
+        || diagnosisState.specialMemo.trim()
+      );
+    }
+
+    function loadDiagnosisState() {
+      try {
+        return normalizeDiagnosisState(JSON.parse(window.localStorage.getItem(diagnosisStorageKey) || '{}'));
+      } catch (error) {
+        return defaultDiagnosisState();
+      }
+    }
+
+    function saveDiagnosisState(state) {
+      window.localStorage.setItem(diagnosisStorageKey, JSON.stringify(normalizeDiagnosisState(state)));
+    }
+
+    function clearDiagnosisState() {
+      window.localStorage.removeItem(diagnosisStorageKey);
+    }
+
+    function buildDiagnosisChipGroup(options, fieldName, multiSelect) {
+      return options.map((option) => `
+        <button
+          type="button"
+          class="diagnosis-chip${multiSelect ? ' multi' : ''}"
+          data-field="${fieldName}"
+          data-value="${option.value}"
+          data-multi="${multiSelect ? 'true' : 'false'}"
+          aria-pressed="false"
+        >
+          ${escapeHtml(option.label)}
+        </button>
+      `).join('');
+    }
+
+    function findDiagnosisOption(fieldName, value) {
+      return (diagnosisOptionGroups[fieldName] || []).find((option) => option.value === value) || null;
+    }
+
+    function getDiagnosisValueLabel(fieldName, value, fallback = '선택 전') {
+      if (!value) {
+        return fallback;
+      }
+
+      const option = findDiagnosisOption(fieldName, value);
+      return option ? option.label : fallback;
+    }
+
+    function setDiagnosisValueText(elementId, text, isEmpty) {
+      const target = document.getElementById(elementId);
+      if (!target) {
+        return;
+      }
+
+      target.textContent = text;
+      target.classList.toggle('is-empty', Boolean(isEmpty));
+    }
+
+    function renderDiagnosisSelectionPills(values) {
+      if (!Array.isArray(values) || values.length === 0) {
+        return '<span class="diagnosis-selection-pill is-empty">선택 전</span>';
+      }
+
+      return values.map((value) => {
+        const label = getDiagnosisValueLabel('specialNotes', value, value);
+        return `<span class="diagnosis-selection-pill">${escapeHtml(label)}</span>`;
+      }).join('');
+    }
+
+    function updateDiagnosisSummary(state) {
+      const diagnosisState = normalizeDiagnosisState(state);
+      const hasMemo = Boolean(diagnosisState.specialMemo.trim());
+      const notePreview = hasMemo
+        ? diagnosisState.specialMemo.trim()
+        : '메모 없음';
+      const clippedNotePreview = hasMemo && notePreview.length > 96
+        ? `${notePreview.slice(0, 96)}...`
+        : notePreview;
+
+      setDiagnosisValueText(
+        'designerDiagnosisHairTextureValue',
+        getDiagnosisValueLabel('hairTexture', diagnosisState.hairTexture),
+        !diagnosisState.hairTexture
+      );
+      setDiagnosisValueText(
+        'designerDiagnosisDamageLevelValue',
+        getDiagnosisValueLabel('damageLevel', diagnosisState.damageLevel),
+        !diagnosisState.damageLevel
+      );
+
+      const specialNotesSummary = document.getElementById('designerDiagnosisSpecialNotesValue');
+      if (specialNotesSummary) {
+        specialNotesSummary.innerHTML = renderDiagnosisSelectionPills(diagnosisState.specialNotes);
+      }
+
+      const memoPreview = document.getElementById('designerDiagnosisMemoPreview');
+      if (memoPreview) {
+        memoPreview.innerHTML = escapeHtml(clippedNotePreview).replace(/\n/g, '<br>');
+        memoPreview.classList.toggle('is-empty', !hasMemo);
+      }
+
+      [
+        ['hairTexture', Boolean(diagnosisState.hairTexture)],
+        ['damageLevel', Boolean(diagnosisState.damageLevel)],
+        ['specialNotes', diagnosisState.specialNotes.length > 0],
+        ['specialMemo', hasMemo]
+      ].forEach(([fieldName, isFilled]) => {
+        const card = detailContent.querySelector(`[data-diagnosis-card="${fieldName}"]`);
+        if (card) {
+          card.classList.toggle('is-filled', isFilled);
+        }
+      });
+    }
+
+    function setDiagnosisEditorCollapsed(nextCollapsed) {
+      diagnosisEditorCollapsed = Boolean(nextCollapsed);
+
+      const shell = detailContent.querySelector('.diagnosis-shell');
+      const editActions = document.getElementById('diagnosisEditActions');
+      const toggleBtn = document.getElementById('toggleDiagnosisEditorBtn');
+
+      if (shell) {
+        shell.classList.toggle('is-collapsed', diagnosisEditorCollapsed);
+      }
+
+      if (editActions) {
+        editActions.style.display = diagnosisEditorCollapsed ? 'none' : 'flex';
+      }
+
+      if (toggleBtn) {
+        toggleBtn.textContent = diagnosisEditorCollapsed ? '수정하기' : '요약만 보기';
+        toggleBtn.classList.remove('btn-primary', 'btn-dark');
+        toggleBtn.classList.add('btn', diagnosisEditorCollapsed ? 'btn-primary' : 'btn-dark');
+      }
+    }
+
+    function buildDiagnosisSection() {
+      return `
+        <div class="info-group">
+          <div class="diagnosis-shell">
+            <div class="action-strip">
+              <div class="action-copy">
+                <span class="info-label">디자이너 진단 카드</span>
+                <p class="diagnosis-copy">고객 취향 카드 바로 아래에서 같은 방식으로 현재 진단 상태를 정리하고 바로 수정할 수 있습니다.</p>
+              </div>
+            </div>
+
+            <div class="diagnosis-meta">
+              <strong>프론트 임시 저장 모드</strong>
+              <p>지금은 서버 저장 없이 이 브라우저에만 임시 저장됩니다. 백엔드 연결 전까지 빠르게 입력 흐름을 확인하는 용도입니다.</p>
+            </div>
+
+            <div class="diagnosis-grid">
+              <section class="survey-item diagnosis-item" data-diagnosis-card="hairTexture">
+                <div class="diagnosis-item-head">
+                  <span class="survey-tag">모질</span>
+                  <div class="diagnosis-value-row">
+                    <div id="designerDiagnosisHairTextureValue" class="survey-value diagnosis-value is-empty">선택 전</div>
+                    <span class="diagnosis-edit-badge">수정 가능</span>
+                  </div>
+                  <p class="diagnosis-help">펌제 침투 속도와 방치 시간을 결정하는 기준입니다.</p>
+                </div>
+                <div class="diagnosis-chip-group diagnosis-editor-block">
+                  ${buildDiagnosisChipGroup(diagnosisOptionGroups.hairTexture, 'hairTexture', false)}
+                </div>
+              </section>
+
+              <section class="survey-item diagnosis-item" data-diagnosis-card="damageLevel">
+                <div class="diagnosis-item-head">
+                  <span class="survey-tag">손상도</span>
+                  <div class="diagnosis-value-row">
+                    <div id="designerDiagnosisDamageLevelValue" class="survey-value diagnosis-value is-empty">선택 전</div>
+                    <span class="diagnosis-edit-badge">수정 가능</span>
+                  </div>
+                  <p class="diagnosis-help">시술 가능 여부, 열기구 온도, 전처리 강도를 판단하는 기준입니다.</p>
+                </div>
+                <div class="diagnosis-chip-group diagnosis-editor-block">
+                  ${buildDiagnosisChipGroup(diagnosisOptionGroups.damageLevel, 'damageLevel', false)}
+                </div>
+              </section>
+
+              <section class="survey-item diagnosis-item" data-diagnosis-card="specialNotes">
+                <div class="diagnosis-item-head">
+                  <span class="survey-tag">특이사항 및 히스토리</span>
+                  <div class="diagnosis-value-row">
+                    <div id="designerDiagnosisSpecialNotesValue" class="diagnosis-selection-list">
+                      <span class="diagnosis-selection-pill is-empty">선택 전</span>
+                    </div>
+                    <span class="diagnosis-edit-badge">복수 선택</span>
+                  </div>
+                  <p class="diagnosis-help">시술 사고 방지와 상담 맥락 정리에 필요한 항목입니다. 여러 개를 함께 체크할 수 있습니다.</p>
+                </div>
+                <div class="diagnosis-chip-group diagnosis-editor-block">
+                  ${buildDiagnosisChipGroup(diagnosisOptionGroups.specialNotes, 'specialNotes', true)}
+                </div>
+              </section>
+
+              <section class="survey-item diagnosis-item is-wide" data-diagnosis-card="specialMemo">
+                <div class="diagnosis-item-head">
+                  <span class="survey-tag">추가 메모</span>
+                  <div class="diagnosis-value-row">
+                    <div id="designerDiagnosisMemoPreview" class="diagnosis-note-preview is-empty">메모 없음</div>
+                    <span class="diagnosis-edit-badge">직접 입력</span>
+                  </div>
+                  <p class="diagnosis-help">모발 상태, 상담 포인트, 주의사항처럼 자유롭게 남기고 싶은 내용을 적어둘 수 있습니다.</p>
+                </div>
+                <div class="diagnosis-editor-block">
+                  <textarea id="designerDiagnosisMemo" class="form-input diagnosis-textarea" placeholder="예: 뿌리 볼륨은 필요하지만 끝선 손상이 있어 열기구 온도를 낮춰야 함"></textarea>
+                </div>
+              </section>
+            </div>
+
+            <div class="diagnosis-actions">
+              <div id="diagnosisEditActions" class="diagnosis-actions-left">
+                <button type="button" id="saveDiagnosisDraftBtn" class="btn btn-primary" style="height: 46px; padding: 0 20px;">임시 저장</button>
+                <button type="button" id="resetDiagnosisDraftBtn" class="btn btn-dark" style="height: 46px; padding: 0 20px;">초기화</button>
+              </div>
+              <div class="diagnosis-actions-right">
+                <button type="button" id="toggleDiagnosisEditorBtn" class="btn btn-dark" style="height: 46px; padding: 0 20px;">요약만 보기</button>
+                <div id="diagnosisDraftStatus" class="diagnosis-status is-muted">브라우저 임시 저장 전</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      `;
+    }
+
+    function applyDiagnosisState(state) {
+      const diagnosisState = normalizeDiagnosisState(state);
+      const chips = detailContent.querySelectorAll('.diagnosis-chip');
+
+      chips.forEach((chip) => {
+        const field = chip.dataset.field;
+        const value = chip.dataset.value;
+        const isMulti = chip.dataset.multi === 'true';
+        const selected = isMulti
+          ? diagnosisState.specialNotes.includes(value)
+          : diagnosisState[field] === value;
+
+        chip.classList.toggle('is-selected', selected);
+        chip.setAttribute('aria-pressed', selected ? 'true' : 'false');
+      });
+
+      const memoField = document.getElementById('designerDiagnosisMemo');
+      if (memoField) {
+        memoField.value = diagnosisState.specialMemo;
+      }
+
+      updateDiagnosisSummary(diagnosisState);
+    }
+
+    function collectDiagnosisState() {
+      const nextState = defaultDiagnosisState();
+
+      ['hairTexture', 'damageLevel'].forEach((fieldName) => {
+        const selectedChip = detailContent.querySelector(`.diagnosis-chip[data-field="${fieldName}"].is-selected`);
+        nextState[fieldName] = selectedChip ? selectedChip.dataset.value : '';
+      });
+
+      nextState.specialNotes = Array.from(
+        detailContent.querySelectorAll('.diagnosis-chip[data-field="specialNotes"].is-selected')
+      ).map((chip) => chip.dataset.value);
+
+      const memoField = document.getElementById('designerDiagnosisMemo');
+      nextState.specialMemo = memoField ? memoField.value.trim() : '';
+
+      return nextState;
+    }
+
+    function setDiagnosisStatus(message, tone) {
+      const statusEl = document.getElementById('diagnosisDraftStatus');
+      if (!statusEl) {
+        return;
+      }
+
+      statusEl.textContent = message;
+      statusEl.classList.remove('is-success', 'is-muted');
+      statusEl.classList.add(tone === 'success' ? 'is-success' : 'is-muted');
+    }
+
+    function bindDiagnosisCard() {
+      const chips = detailContent.querySelectorAll('.diagnosis-chip');
+      const memoField = document.getElementById('designerDiagnosisMemo');
+      const saveBtn = document.getElementById('saveDiagnosisDraftBtn');
+      const resetBtn = document.getElementById('resetDiagnosisDraftBtn');
+      const toggleBtn = document.getElementById('toggleDiagnosisEditorBtn');
+      const savedState = loadDiagnosisState();
+      const hasSavedDiagnosis = hasDiagnosisContent(savedState);
+
+      applyDiagnosisState(savedState);
+      setDiagnosisEditorCollapsed(hasSavedDiagnosis);
+
+      if (hasSavedDiagnosis) {
+        setDiagnosisStatus('이 브라우저에 저장된 진단 초안을 불러왔습니다.', 'success');
+      }
+
+      chips.forEach((chip) => {
+        chip.addEventListener('click', () => {
+          const field = chip.dataset.field;
+          const isMulti = chip.dataset.multi === 'true';
+          const wasSelected = chip.classList.contains('is-selected');
+
+          if (isMulti) {
+            chip.classList.toggle('is-selected');
+            chip.setAttribute('aria-pressed', chip.classList.contains('is-selected') ? 'true' : 'false');
+          } else {
+            detailContent.querySelectorAll(`.diagnosis-chip[data-field="${field}"]`).forEach((item) => {
+              item.classList.remove('is-selected');
+              item.setAttribute('aria-pressed', 'false');
+            });
+            if (!wasSelected) {
+              chip.classList.add('is-selected');
+              chip.setAttribute('aria-pressed', 'true');
+            }
+          }
+
+          updateDiagnosisSummary(collectDiagnosisState());
+          setDiagnosisStatus('변경 내용이 있습니다. 임시 저장을 눌러 보관할 수 있습니다.', 'muted');
+        });
+      });
+
+      if (memoField) {
+        memoField.addEventListener('input', () => {
+          updateDiagnosisSummary(collectDiagnosisState());
+          setDiagnosisStatus('메모가 변경되었습니다. 임시 저장을 눌러 보관할 수 있습니다.', 'muted');
+        });
+      }
+
+      if (saveBtn) {
+        saveBtn.addEventListener('click', () => {
+          const nextState = collectDiagnosisState();
+          saveDiagnosisState(nextState);
+          setDiagnosisEditorCollapsed(true);
+          setDiagnosisStatus('디자이너 진단 카드가 이 브라우저에 임시 저장되었습니다.', 'success');
+        });
+      }
+
+      if (resetBtn) {
+        resetBtn.addEventListener('click', () => {
+          clearDiagnosisState();
+          applyDiagnosisState(defaultDiagnosisState());
+          setDiagnosisEditorCollapsed(false);
+          setDiagnosisStatus('임시 저장된 진단 카드 내용을 초기화했습니다.', 'muted');
+        });
+      }
+
+      if (toggleBtn) {
+        toggleBtn.addEventListener('click', () => {
+          setDiagnosisEditorCollapsed(!diagnosisEditorCollapsed);
+          setDiagnosisStatus(
+            diagnosisEditorCollapsed
+              ? '저장된 진단 카드 요약만 보고 있습니다. 수정하려면 수정하기를 눌러 주세요.'
+              : '디자이너 진단 카드를 다시 수정할 수 있습니다.',
+            'muted'
+          );
+        });
+      }
+    }
+
+    function showRetryStatus(message) {
+      retryStatusMessage.textContent = message;
+      retryStatusMessage.classList.remove('is-hidden');
+    }
+
+    function resetRetryStatus() {
+      retryStatusMessage.textContent = '';
+      retryStatusMessage.classList.add('is-hidden');
+    }
+
+    function buildRetryPreview(items) {
+      if (!Array.isArray(items) || items.length === 0) {
+        return `
+          <div class="info-group">
+            <span class="info-label">재분석 결과</span>
+            <p class="section-copy" style="margin-bottom: 0;">새 추천 결과가 생성되었지만 미리보기 데이터는 아직 없습니다.</p>
+          </div>
+        `;
+      }
+
+      const previewCards = items.slice(0, 3).map((item) => `
+        <div class="preview-card">
+          <strong>${escapeHtml(item.style_name || '추천 스타일')}</strong>
+          <div style="font-size: 13px; color: var(--text-secondary); line-height: 1.5;">
+            매칭률 ${escapeHtml(item.match_score ?? 0)}%
+          </div>
+          <div style="font-size: 12px; color: var(--text-secondary); line-height: 1.5; margin-top: 8px;">
+            ${escapeHtml(item.reasoning || item.style_description || '추천 설명이 준비 중입니다.')}
+          </div>
+        </div>
+      `).join('');
+
+      return `
+        <div class="info-group">
+          <div class="action-strip">
+            <div class="action-copy">
+              <span class="info-label">재분석 결과 미리보기</span>
+              <p>기존 취향을 유지한 재분석이 완료되었습니다. 최신 추천 상위 결과를 바로 확인할 수 있습니다.</p>
+            </div>
+          </div>
+          <div class="preview-list">${previewCards}</div>
+        </div>
+      `;
+    }
+
+    function renderCustomerDetail(customer) {
+      const surveyCreatedAt = customer.survey && customer.survey.created_at;
+      const firstAnalysis = Array.isArray(customer.face_analyses) ? customer.face_analyses[0] : null;
+      const firstCapture = Array.isArray(customer.captures) ? customer.captures[0] : null;
+      const hasReusablePreference = hasSurveyData(customer) && hasFaceAnalysis(customer);
+
       detailContent.innerHTML = `
         <div class="info-group">
-          <h3 class="section-title" style="font-size: 22px; margin-bottom: 8px;">${customer.name} 고객님</h3>
-          <p style="color: var(--text-secondary); font-size: 14px;">${customer.phone} | 분석일: ${new Date(customer.created_at).toLocaleDateString()}</p>
+          <h3 class="section-title" style="font-size: 22px; margin-bottom: 8px;">${escapeHtml(customer.name)} 고객님</h3>
+          <p style="color: var(--text-secondary); font-size: 14px; margin-bottom: 0;">
+            ${escapeHtml(customer.phone || '연락처 없음')} | 최근 분석일 ${escapeHtml(formatDate(surveyCreatedAt || (firstAnalysis && firstAnalysis.created_at) || (firstCapture && firstCapture.created_at)))}
+          </p>
         </div>
 
         <div class="info-group">
-          <span class="info-label">스타일 취향 분석 (Survey Data)</span>
+          <span class="info-label">스타일 취향 분석</span>
           <div class="survey-grid">
-            <div class="survey-item"><span class="survey-tag">희망 길이</span><div class="survey-value">${customer.survey?.target_length || '미지정'}</div></div>
-            <div class="survey-item"><span class="survey-tag">선호 분위기</span><div class="survey-value">${customer.survey?.target_vibe || '미지정'}</div></div>
-            <div class="survey-item"><span class="survey-tag">두피 상태</span><div class="survey-value">${customer.survey?.scalp_type || '미지정'}</div></div>
-            <div class="survey-item"><span class="survey-tag">모발 컬러</span><div class="survey-value">${customer.survey?.hair_colour || '미지정'}</div></div>
-            <div class="survey-item"><span class="survey-tag">예산 범위</span><div class="survey-value">${customer.survey?.budget_range || '미지정'}</div></div>
-            <div class="survey-item"><span class="survey-tag">연령대</span><div class="survey-value">${customer.age_input || customer.age_group || '미지정'}</div></div>
+            <div class="survey-item"><span class="survey-tag">희망 길이</span><div class="survey-value">${escapeHtml(customer.survey && customer.survey.target_length || '미지정')}</div></div>
+            <div class="survey-item"><span class="survey-tag">선호 분위기</span><div class="survey-value">${escapeHtml(customer.survey && customer.survey.target_vibe || '미지정')}</div></div>
+            <div class="survey-item"><span class="survey-tag">두피 상태</span><div class="survey-value">${escapeHtml(customer.survey && customer.survey.scalp_type || '미지정')}</div></div>
+            <div class="survey-item"><span class="survey-tag">모발 컬러</span><div class="survey-value">${escapeHtml(customer.survey && customer.survey.hair_colour || '미지정')}</div></div>
+            <div class="survey-item"><span class="survey-tag">예산 범위</span><div class="survey-value">${escapeHtml(customer.survey && customer.survey.budget_range || '미지정')}</div></div>
+            <div class="survey-item"><span class="survey-tag">얼굴형 분석</span><div class="survey-value">${escapeHtml(firstAnalysis && firstAnalysis.face_shape || '미분석')}</div></div>
           </div>
         </div>
 
-        <div class="info-group" style="border-bottom: none; margin-bottom: 0;">
+        ${buildDiagnosisSection()}
+
+        <div class="info-group">
+          <div class="action-strip">
+            <div class="action-copy">
+              <span class="info-label">재분석</span>
+              <p>고객 취향을 그대로 유지하거나, 취향을 다시 선택한 뒤 새로운 추천 흐름으로 이어갈 수 있습니다.</p>
+              <div class="retry-hint">
+                ${hasReusablePreference ? '저장된 설문과 얼굴 분석이 있어 기존 취향 유지 재분석을 바로 실행할 수 있습니다.' : '기존 취향 유지 재분석은 설문과 얼굴 분석이 모두 있을 때 사용할 수 있습니다.'}
+              </div>
+            </div>
+            <button id="openRetryChoiceBtn" class="btn btn-primary" style="height: 48px; padding: 0 24px;">재분석</button>
+          </div>
+        </div>
+
+        ${latestRetryPreviewHtml}
+
+        <div class="info-group">
           <span class="info-label">디자이너 상담 메모</span>
           <textarea class="form-input" style="height: 120px; padding: 16px; font-size: 14px;" placeholder="상담 내용을 입력하세요..."></textarea>
           <button class="btn btn-dark" style="margin-top: 16px; width: 100%;">상담 내용 저장</button>
         </div>
       `;
-    } catch (e) {
-      detailContent.innerHTML = `<div style="text-align: center; padding: 60px; color: var(--status-red);">고객 정보를 불러올 수 없습니다.</div>`;
+
+      const openRetryChoiceBtn = document.getElementById('openRetryChoiceBtn');
+      if (openRetryChoiceBtn) {
+        openRetryChoiceBtn.addEventListener('click', () => openRetryChoice(hasReusablePreference));
+      }
+
+      bindDiagnosisCard();
     }
+
+    function openRetryChoice(hasReusablePreference) {
+      retryKeepPreferenceBtn.disabled = !hasReusablePreference;
+      retryKeepPreferenceBtn.style.opacity = hasReusablePreference ? '1' : '0.55';
+      retryKeepPreferenceBtn.title = hasReusablePreference ? '' : '설문과 얼굴 분석 데이터가 있어야 기존 취향 유지 재분석을 실행할 수 있습니다.';
+      resetRetryStatus();
+      retryChoiceModal.classList.remove('is-hidden');
+      retryChoiceModal.setAttribute('aria-hidden', 'false');
+    }
+
+    window.hideRetryChoice = function () {
+      retryChoiceModal.classList.add('is-hidden');
+      retryChoiceModal.setAttribute('aria-hidden', 'true');
+      retryKeepPreferenceBtn.disabled = false;
+      retryChooseAgainBtn.disabled = false;
+      retryKeepPreferenceBtn.textContent = '바로 재분석';
+      retryChooseAgainBtn.textContent = '설문 다시 선택';
+      resetRetryStatus();
+    };
+
+    async function retryWithSavedPreference() {
+      retryKeepPreferenceBtn.disabled = true;
+      retryChooseAgainBtn.disabled = true;
+      retryKeepPreferenceBtn.textContent = '재분석 중...';
+      showRetryStatus('저장된 취향 데이터를 사용해 재분석을 진행하고 있습니다.');
+
+      try {
+        const response = await fetch('/api/v1/analysis/retry-recommendations/', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': '{{ csrf_token }}'
+          },
+          body: JSON.stringify({ customer_id: parseInt(clientId, 10) })
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data.detail || data.message || '재분석에 실패했습니다.');
+        }
+
+        latestRetryPreviewHtml = buildRetryPreview(data.items || []);
+        renderCustomerDetail(currentCustomer);
+        hideRetryChoice();
+        alert('기존 취향 유지 재분석이 완료되었습니다.');
+      } catch (error) {
+        retryKeepPreferenceBtn.disabled = false;
+        retryChooseAgainBtn.disabled = false;
+        retryKeepPreferenceBtn.textContent = '바로 재분석';
+        showRetryStatus(error.message);
+      }
+    }
+
+    function retryWithNewPreference() {
+      retryChooseAgainBtn.disabled = true;
+      retryChooseAgainBtn.textContent = '안내 중...';
+      showRetryStatus('취향 다시 선택 흐름은 백엔드 세션 연결 후 이어질 예정입니다.');
+    }
+
+    retryKeepPreferenceBtn.addEventListener('click', retryWithSavedPreference);
+    retryChooseAgainBtn.addEventListener('click', retryWithNewPreference);
+
+    retryChoiceModal.addEventListener('click', (event) => {
+      if (event.target === retryChoiceModal) {
+        hideRetryChoice();
+      }
+    });
+
+    (async function fetchCustomerDetail() {
+      try {
+        const response = await fetch(`/api/v1/customers/${clientId}/`);
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data.detail || data.message || '고객 정보를 불러올 수 없습니다.');
+        }
+
+        currentCustomer = data.data || data;
+        if (!currentCustomer) {
+          throw new Error('고객 정보를 찾을 수 없습니다.');
+        }
+
+        renderCustomerDetail(currentCustomer);
+      } catch (error) {
+        detailContent.innerHTML = `<div style="text-align: center; padding: 60px; color: var(--status-red);">${escapeHtml(error.message)}</div>`;
+      }
+    })();
   })();
 </script>
 {% endblock %}

--- a/backend/templates/admin/designer_delete.html
+++ b/backend/templates/admin/designer_delete.html
@@ -12,7 +12,7 @@
 {% block content %}
 <div class="customer-layout" style="display: block;">
   <div class="panel" style="max-width: 960px; margin: 0 auto; padding: 32px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
-    <h3 class="section-title" style="margin-bottom: 12px;">{{ active_shop.store_name }} 디자이너 비활성화</h3>
+    <h3 class="section-title" style="margin-bottom: 12px;">{{ active_shop.store_name|default:request.session.admin_store_name|default:request.session.admin_name|default:"MirrAI Partner" }} 디자이너 비활성화</h3>
     <p class="section-copy" style="margin-bottom: 24px;">삭제 대신 비활성화되어 기존 고객 기록은 유지됩니다.</p>
 
     {% if form_error %}

--- a/backend/templates/admin/designer_management.html
+++ b/backend/templates/admin/designer_management.html
@@ -14,7 +14,7 @@
   <div class="panel" style="max-width: 960px; margin: 0 auto; padding: 32px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
     <div style="display: flex; justify-content: space-between; align-items: center; gap: 16px; flex-wrap: wrap; margin-bottom: 24px;">
       <div>
-        <h3 class="section-title" style="margin-bottom: 6px;">{{ active_shop.store_name }}</h3>
+        <h3 class="section-title" style="margin-bottom: 6px;">{{ active_shop.store_name|default:request.session.admin_store_name|default:request.session.admin_name|default:"MirrAI Partner" }}</h3>
         <p class="section-copy" style="margin-bottom: 0;">현재 등록된 디자이너를 관리합니다.</p>
       </div>
       <div style="display: flex; gap: 12px; flex-wrap: wrap;">

--- a/backend/templates/admin/designer_signup.html
+++ b/backend/templates/admin/designer_signup.html
@@ -12,7 +12,7 @@
 {% block content %}
 <div class="customer-layout" style="display: block;">
   <div class="panel" style="max-width: 720px; margin: 0 auto; padding: 32px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
-    <h3 class="section-title" style="margin-bottom: 12px;">{{ active_shop.store_name }} 디자이너 등록</h3>
+    <h3 class="section-title" style="margin-bottom: 12px;">{{ active_shop.store_name|default:request.session.admin_store_name|default:request.session.admin_name|default:"MirrAI Partner" }} 디자이너 등록</h3>
     <p class="section-copy" style="margin-bottom: 24px;">이 디자이너는 현재 매장 계정에 종속되어 고객 배정과 로그인에 사용됩니다.</p>
 
     {% if form_error %}

--- a/backend/templates/admin/index.html
+++ b/backend/templates/admin/index.html
@@ -6,8 +6,21 @@
 
 {% block hero_content %}
 <div style="max-width: 1200px; margin: 0 auto; width: 100%; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap;">
-  <h2 class="hero-title" style="margin-bottom: 0; font-size: 24px;"><span id="heroTitleText">파트너 센터</span></h2>
-  <p class="section-copy" id="heroSubText" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">매장 운영 및 디자이너 관리 대시보드입니다.</p>
+  {% if is_dashboard %}
+    <h2 class="hero-title" style="margin-bottom: 0; font-size: 24px;">
+      <span id="heroTitleText">{% if is_designer_session %}디자이너 대시보드{% else %}매장 대시보드{% endif %}</span>
+    </h2>
+    <p class="section-copy" id="heroSubText" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">
+      {% if is_designer_session %}
+        담당 고객과 상담 흐름을 관리하는 디자이너 전용 화면입니다.
+      {% else %}
+        매장 운영 현황과 디자이너 배정 상태를 확인하는 매장 전용 화면입니다.
+      {% endif %}
+    </p>
+  {% else %}
+    <h2 class="hero-title" style="margin-bottom: 0; font-size: 24px;"><span id="heroTitleText">파트너 센터</span></h2>
+    <p class="section-copy" id="heroSubText" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">매장 운영 및 디자이너 관리 대시보드입니다.</p>
+  {% endif %}
 </div>
 {% endblock %}
 
@@ -82,7 +95,15 @@
   {% if is_dashboard %}
     <article class="main-content panel stack dashboard-panel">
       <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 32px;">
-        <div><h2 class="section-title" style="margin-bottom: 4px;">{{ designer.name|default:admin.store_name }} 님</h2><p class="section-copy">{{ admin.store_name }} 대시보드</p></div>
+        <div>
+          {% if is_designer_session %}
+            <h2 class="section-title" style="margin-bottom: 4px;">{{ designer.name }} 디자이너 대시보드</h2>
+            <p class="section-copy">{{ admin.store_name }} 매장 고객 현황</p>
+          {% else %}
+            <h2 class="section-title" style="margin-bottom: 4px;">{{ admin.store_name }} 매장 대시보드</h2>
+            <p class="section-copy">고객 현황과 디자이너 배정 상태를 한눈에 확인할 수 있습니다.</p>
+          {% endif %}
+        </div>
         <div style="display: flex; gap: 12px; align-items: center;">
           {% if not request.session.designer_id %}
             <select id="designerSelect" class="form-control" style="width: auto; height: 36px; font-size: 13px; padding: 0 12px; border-radius: 8px;">
@@ -158,7 +179,16 @@
         if (data.status === 'success') {
           updateStatus("로그인 성공!", "success");
           const urlParams = new URLSearchParams(window.location.search);
-          const nextUrl = urlParams.get('next') || "{% url 'partner_designer_select' %}";
+          const defaultNextUrl = (
+            data.redirect && data.redirect !== '/partner/login/'
+          )
+            ? data.redirect
+            : (
+              data.next_step === 'designer_select'
+                ? "{% url 'partner_designer_select' %}"
+                : "{% url 'partner_dashboard' %}"
+            );
+          const nextUrl = urlParams.get('next') || defaultNextUrl;
           setTimeout(() => { window.location.href = nextUrl; }, 600);
         } else { handleFail(data.message); }
       } catch (e) { handleFail("통신 오류가 발생했습니다."); }
@@ -175,12 +205,14 @@
     const reportView = document.getElementById('reportViewContainer');
     let dashboardDesigners = [];
 
-    async function fetchDesigners() {
+    async function fetchDashboardDesigners() {
       if (!designerSelect) return;
       try {
-        const response = await fetch('/api/v1/admin/designers/');
+        const response = await fetch('/api/v1/designers/');
         const data = await response.json();
-        const designers = data.data || data;
+        const designers = Array.isArray(data) ? data : (data.data || []);
+        dashboardDesigners = designers;
+        designerSelect.innerHTML = '<option value="">디자이너</option>';
         if (Array.isArray(designers)) {
           designers.forEach(d => {
             const opt = document.createElement('option');
@@ -236,16 +268,6 @@
         return matchesName && matchesDesigner && matchesPeriod;
       });
       renderCustomers(filtered);
-    }
-
-    async function fetchDesigners() {
-      try {
-        const response = await fetch('/api/v1/designers/');
-        const data = await response.json();
-        dashboardDesigners = Array.isArray(data) ? data : (data.data || []);
-      } catch (e) {
-        dashboardDesigners = [];
-      }
     }
 
     async function assignCustomer(customerId) {
@@ -321,7 +343,7 @@
     }
 
     document.addEventListener('DOMContentLoaded', () => {
-      if ("{{ is_dashboard }}" === "True") { fetchDesigners(); fetchCustomers(); }
+      if ("{{ is_dashboard }}" === "True") { fetchDashboardDesigners(); fetchCustomers(); }
       if (authSection) setTimeout(() => authSection.classList.add('ready'), 100);
       const loginInputs = ['inputPhone', 'inputShopPw'];
       loginInputs.forEach(id => {

--- a/backend/templates/customer/result.html
+++ b/backend/templates/customer/result.html
@@ -122,11 +122,24 @@
 {% block hero_content %}
 <div style="max-width: 1200px; margin: 0 auto; width: 100%; display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap;">
   <h2 class="hero-title" style="margin-bottom: 0; font-size: 24px;">Step 04. <span>추천 결과 확인</span></h2>
-  <p class="section-copy" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">마음에 드는 스타일을 고르거나 바로 상담을 요청할 수 있습니다.</p>
+  <p class="section-copy" style="color: rgba(255, 255, 255, 0.7); margin-bottom: 0; font-size: 14px;">
+    {% if request.GET.reanalysis %}
+      다시 선택한 취향을 반영한 최신 추천 결과입니다.
+    {% else %}
+      마음에 드는 스타일을 고르거나 바로 상담을 요청할 수 있습니다.
+    {% endif %}
+  </p>
 </div>
 {% endblock %}
 
 {% block content %}
+{% if request.GET.reanalysis %}
+<div class="panel" style="margin: 0 auto 24px; max-width: 1080px; padding: 18px 22px;">
+  <strong style="display: block; margin-bottom: 6px; color: var(--bg-dark);">취향 다시 선택이 반영되었습니다.</strong>
+  <p class="section-copy" style="font-size: 13px; margin-bottom: 0;">새로운 취향 설문을 기준으로 추천 결과를 다시 생성했습니다.</p>
+</div>
+{% endif %}
+
 <div id="loadingResults" style="padding: 100px 0; text-align: center;">
   <div style="width: 64px; height: 64px; border: 4px solid var(--line); border-top-color: var(--accent-neon); border-radius: 50%; animation: spin 1s linear infinite; margin: 0 auto 24px;"></div>
   <p class="section-title">AI가 최적의 조합을 찾는 중입니다...</p>

--- a/backend/templates/customer/survey.html
+++ b/backend/templates/customer/survey.html
@@ -153,6 +153,12 @@
 {% block content %}
 <div class="panel customer-input-card survey-mode">
   <h3 class="section-title compact">스타일 취향 설문</h3>
+  {% if request.GET.reanalysis %}
+    <div style="margin-bottom: 18px; padding: 14px 16px; border-radius: 14px; background: rgba(12, 10, 7, 0.04); border: 1px solid rgba(12, 10, 7, 0.08);">
+      <strong style="display: block; margin-bottom: 6px; color: var(--bg-dark);">재분석용 취향 다시 선택</strong>
+      <p style="margin: 0; color: var(--text-secondary); font-size: 13px; line-height: 1.6;">이전에 저장된 취향 대신 새로운 취향으로 다시 추천을 생성하는 흐름입니다.</p>
+    </div>
+  {% endif %}
   
   <form id="surveyForm" action="/api/v1/survey/" method="post" novalidate>
     {% csrf_token %}
@@ -394,8 +400,8 @@
     </div>
 
     <div class="action-row">
-      <button type="submit" id="submitBtn" class="btn btn-primary">취향 분석 완료</button>
-      <a href="{% url 'customer_camera' %}" class="btn btn-outline">이전 단계</a>
+      <button type="submit" id="submitBtn" class="btn btn-primary">{% if request.GET.reanalysis %}취향 다시 선택 완료{% else %}취향 분석 완료{% endif %}</button>
+      <a href="{% url 'customer_camera' %}" class="btn btn-outline">{% if request.GET.reanalysis %}이전 화면{% else %}이전 단계{% endif %}</a>
     </div>
   </form>
 </div>
@@ -407,6 +413,9 @@
     'use strict';
     const form = document.getElementById('surveyForm');
     const submitBtn = document.getElementById('submitBtn');
+    const urlParams = new URLSearchParams(window.location.search);
+    const isReanalysisFlow = urlParams.get('reanalysis') === '1';
+    const reanalysisCustomerId = urlParams.get('customer_id');
 
     document.querySelectorAll('.survey-card').forEach(card => {
       card.addEventListener('click', function() {
@@ -426,6 +435,9 @@
       formData.forEach((value, key) => {
         if (key !== 'csrfmiddlewaretoken') data[key] = value;
       });
+      if (isReanalysisFlow && reanalysisCustomerId) {
+        data.customer_id = reanalysisCustomerId;
+      }
 
       // 필수 체크 (6개 항목 모두 답변했는지 확인)
       const answeredCount = Object.keys(data).filter(key => key.startsWith('q')).length;
@@ -447,11 +459,11 @@
           body: JSON.stringify(data)
         });
         if (!response.ok) throw new Error("Survey submission failed");
-        window.location.href = "/customer/recommendations/";
+        window.location.href = isReanalysisFlow ? "/customer/recommendations/?reanalysis=1" : "/customer/recommendations/";
       } catch (error) {
         alert("저장 중 오류가 발생했습니다.");
         submitBtn.disabled = false;
-        submitBtn.textContent = "취향 분석 완료";
+        submitBtn.textContent = isReanalysisFlow ? "취향 다시 선택 완료" : "취향 분석 완료";
       }
     });
   })();

--- a/backend/templates/layouts/base_site.html
+++ b/backend/templates/layouts/base_site.html
@@ -22,23 +22,19 @@
 
           <nav class="nav-links">
             {% if not request.session.admin_id %}
-              <!-- 매장 로그인이 안된 경우: 로그인 후 디자이너 선택으로 이동하도록 설정 -->
               <a href="{% url 'partner_index' %}?next=/partner/designer-select/?next=/customer/" class="nav-link">분석 시작하기</a>
             {% elif not request.session.designer_id %}
-              <!-- 매장 로그인은 되었으나 디자이너가 없는 경우: 디자이너 선택으로 바로 이동 -->
               <a href="{% url 'partner_designer_select' %}?next=/customer/" class="nav-link">분석 시작하기</a>
             {% else %}
-              <!-- 모두 완료된 경우: 바로 분석 페이지로 이동 -->
               <a href="{% url 'customer_index' %}" class="nav-link">분석 시작하기</a>
             {% endif %}
-            
+
             {% if request.session.admin_id %}
-              <a href="{% url 'partner_designer_select' %}" class="nav-link">디자이너</a>
-              {% if request.session.designer_name %}
-                <!-- 디자이너 세션이 있을 때는 세션을 전환(종료)하는 경로로 연결 -->
-                <a href="/partner/switch-to-admin/" class="nav-link">파트너 센터</a>
+              {% if request.session.designer_id %}
+                <a href="{% url 'partner_staff_dashboard' %}" class="nav-link">디자이너</a>
               {% else %}
-                <a href="{% url 'partner_staff_dashboard' %}" class="nav-link">파트너 센터</a>
+                <a href="{% url 'partner_designer_select' %}" class="nav-link">디자이너</a>
+                <a href="{% url 'partner_dashboard' %}" class="nav-link">파트너 센터</a>
               {% endif %}
             {% else %}
               <a href="{% url 'partner_index' %}?next=/partner/designer-select/" class="nav-link">디자이너</a>
@@ -46,11 +42,10 @@
             {% endif %}
 
             {% if request.session.admin_store_name or request.session.admin_id %}
-              <!-- 매장(사업자) 로그인 상태 -->
               <div style="display: flex; align-items: center; gap: 12px; margin-left: 12px;">
                 <div style="display: flex; align-items: center; gap: 6px;">
                   <span style="font-size: 13px; color: rgba(255,255,255,0.9); font-weight: 700;">
-                    {{ request.session.admin_store_name|default:"MirrAI Partner" }}
+                    {{ request.session.admin_store_name|default:request.session.admin_name|default:"MirrAI Partner" }}
                   </span>
                   {% if request.session.designer_name %}
                     <span style="font-size: 12px; color: var(--accent-neon); font-weight: 600;">
@@ -58,7 +53,11 @@
                     </span>
                   {% endif %}
                 </div>
-                <a href="{% url 'logout' %}" class="btn btn-dark" style="height: 32px; padding: 0 16px; font-size: 12px; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2);">로그아웃</a>
+                {% if request.session.designer_id %}
+                  <a href="{% url 'designer_logout' %}" data-designer-logout="true" data-after-logout="{% url 'partner_designer_select' %}" class="btn btn-dark" style="height: 32px; padding: 0 16px; font-size: 12px; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2);">로그아웃</a>
+                {% else %}
+                  <a href="{% url 'partner_logout' %}" class="btn btn-dark" style="height: 32px; padding: 0 16px; font-size: 12px; background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2);">로그아웃</a>
+                {% endif %}
               </div>
             {% elif request.session.customer_name %}
               <div style="display: flex; align-items: center; gap: 12px; margin-left: 12px;">
@@ -84,6 +83,7 @@
 
       {% include "components/footer.html" %}
     </div>
+
     {% if popup_message %}
     <script>
       window.addEventListener('DOMContentLoaded', function () {
@@ -91,6 +91,7 @@
       });
     </script>
     {% endif %}
+
     <script>
       window.addEventListener('pageshow', function (event) {
         const restoredFromBackForward = event.persisted || (
@@ -108,6 +109,40 @@
         }
       });
     </script>
+
+    <script>
+      window.addEventListener('DOMContentLoaded', function () {
+        const designerLogoutLink = document.querySelector('[data-designer-logout="true"]');
+        if (!designerLogoutLink) {
+          return;
+        }
+
+        designerLogoutLink.addEventListener('click', async function (event) {
+          event.preventDefault();
+
+          if (designerLogoutLink.dataset.pending === 'true') {
+            return;
+          }
+
+          designerLogoutLink.dataset.pending = 'true';
+          designerLogoutLink.style.pointerEvents = 'none';
+
+          try {
+            await fetch(designerLogoutLink.href, {
+              method: 'GET',
+              credentials: 'same-origin',
+              headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+              }
+            });
+            window.location.href = designerLogoutLink.dataset.afterLogout;
+          } catch (error) {
+            window.location.href = designerLogoutLink.href;
+          }
+        });
+      });
+    </script>
+
     {% block page_scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## 작업 내용
- 파트너 센터 메인 화면에서 매장 대시보드와 디자이너 대시보드 문구를 역할에 맞게 분리했습니다.
- 파트너 대시보드 진입 시 디자이너 목록 조회와 리다이렉트 분기 로직을 정리했습니다.
- 공통 레이아웃에서 디자이너 세션 여부에 따라 상단 네비게이션과 로그아웃 동작이 다르게 보이도록 정리했습니다.
- 디자이너 로그아웃 시 프론트 기준으로 디자이너 선택 화면으로 자연스럽게 이동하는 우회 처리를 추가했습니다.
- 디자이너 관리, 등록, 비활성화 화면에서 매장명 표시가 비어 있을 때 세션 값을 fallback으로 사용하도록 정리했습니다.
- 고객 설문 화면에 재분석용 취향 다시 선택 안내와 분기 문구를 추가했습니다.
- 재분석 흐름에서는 `reanalysis=1`, `customer_id`를 함께 전달해 설문에서 다시 추천 결과로 이어질 수 있도록 프론트 분기를 추가했습니다.
- 고객 추천 결과 화면에 재분석 결과 안내 문구와 상태 배너를 추가했습니다.
- 고객 상세보기 화면을 확장해 고객 설문, 디자이너 진단 카드, 재분석 흐름을 한 화면에서 확인할 수 있도록 정리했습니다.
- 고객 상세보기에는 디자이너 진단 카드 UI를 추가했고, 모질/손상도/특이사항/추가 메모를 입력할 수 있게 했습니다.
- 디자이너 진단 카드는 현재 프론트 기준 `localStorage` 임시 저장으로 동작하며, 저장 후에는 편집 영역이 접히고 요약만 보이도록 처리했습니다.
- 저장된 진단 카드가 있으면 재진입 시 요약 상태로 복원되고, `수정하기`로 다시 펼쳐서 편집할 수 있게 했습니다.
- 고객 상세보기에서 재분석 선택 모달을 추가했고, 기존 취향 유지 재분석과 취향 다시 선택 흐름을 분리했습니다.
- 기존 취향 유지 재분석 완료 시 상위 추천 결과를 상세 화면 안에서 미리보기로 확인할 수 있게 했습니다.

## 수정 파일
- `backend/templates/admin/index.html`
- `backend/templates/layouts/base_site.html`
- `backend/templates/admin/designer_management.html`
- `backend/templates/admin/designer_signup.html`
- `backend/templates/admin/designer_delete.html`
- `backend/templates/customer/survey.html`
- `backend/templates/customer/result.html`
- `backend/templates/admin/customer_detail.html`

## 확인 포인트
- 파트너 로그인과 디자이너 세션 상태에 따라 대시보드 제목과 설명이 올바르게 바뀌는지
- 상단 네비게이션에서 디자이너/파트너 센터 이동 경로가 세션 상태에 맞게 노출되는지
- 디자이너 로그아웃 시 디자이너 선택 화면으로 자연스럽게 이동하는지
- 재분석 흐름에서 설문 화면과 결과 화면 안내 문구가 상황에 맞게 바뀌는지
- 고객 상세보기에서 디자이너 진단 카드가 고객 취향 카드와 유사한 구조로 보이는지
- 진단 카드 입력 후 `임시 저장` 시 요약 상태로 접히는지
- 저장된 상태에서 페이지 재진입 시 요약 상태로 복원되는지
- `수정하기` 클릭 시 다시 편집 가능하게 펼쳐지는지
- 고객 상세보기의 재분석 모달과 기존 취향 유지 재분석 미리보기가 정상 동작하는지

## 참고
- 디자이너 진단 카드와 상담 메모는 아직 백엔드 저장 연결 전이라 프론트 임시 저장 기준으로 동작합니다.
- `취향 다시 선택` 재분석 흐름은 프론트 분기까지 반영되어 있고, 실제 세션 연결은 백엔드 후속 작업이 필요합니다.
- 디자이너 로그아웃은 현재 프론트 우회 처리 기준으로 동작하며, 백엔드 기본 redirect 정리는 후속 검토가 필요합니다.
