### PR TITLE
[162] 사진촬영 업로드 재검증 로그 및 캡처 기준 트러블슈팅 보강

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ BACKEND_API_URL=http://localhost:8000/api/v1
 # [AI Models & External APIs]
 OPENAI_API_KEY=your_openai_api_key_here
 STABLE_DIFFUSION_ENDPOINT=your_sd_endpoint_here
+RUNPOD_ENDPOINT_ID=your_runpod_model_endpoint_id_here
 RUNPOD_API_KEY=your_runpod_api_key_here
 RUNPOD_TRENDS_ENDPOINT_ID=your_runpod_trend_endpoint_id_here
 RUNPOD_BASE_URL=https://api.runpod.ai/v2
@@ -14,7 +15,7 @@ MIRRAI_AI_SERVICE_URL=
 MIRRAI_INTERNAL_API_TOKEN=
 MIRRAI_INTERNAL_API_KEY=
 MIRRAI_AI_API_VERSION=
-MIRRAI_AI_PROVIDER=service
+MIRRAI_AI_PROVIDER=runpod
 
 # [Security & Database]
 JWT_SECRET_KEY=your_super_secret_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ front_feedback/
 
 # Django Specific / App Tests
 docs/
+!docs/
+docs/*
+!docs/runpod_direct_b_refactor_report_0406_ver1.md
 tests/
 app/tests/
 !app/tests/

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ app/tests/
 !app/tests/
 app/tests/*
 !app/tests/test_seed_test_accounts.py
+!app/tests/test_ai_facade.py
 
 # Front Feedback
 !front_feedback/

--- a/app/api/v1/django_views.py
+++ b/app/api/v1/django_views.py
@@ -1,4 +1,5 @@
 ﻿import io
+import json
 import threading
 import logging
 
@@ -36,7 +37,11 @@ from app.api.v1.services_django import (
     upsert_survey,
 )
 from app.services.age_profile import build_client_age_profile
-from app.services.capture_validation import sanitize_original_upload, validate_capture_image
+from app.services.capture_validation import (
+    build_capture_validation_snapshot,
+    sanitize_original_upload,
+    validate_capture_image,
+)
 from app.services.face_processing import build_deidentified_capture, extract_landmark_snapshot
 from app.services.model_team_bridge import (
     create_legacy_capture_upload_record,
@@ -73,6 +78,22 @@ def _get_client_or_404(identifier):
     if client is None:
         raise Http404("Client not found.")
     return client
+
+
+def _parse_front_capture_context(request) -> dict | None:
+    raw_value = request.data.get("front_capture_context")
+    if raw_value in (None, ""):
+        return None
+    if isinstance(raw_value, dict):
+        return raw_value
+    if not isinstance(raw_value, str):
+        return None
+    try:
+        parsed = json.loads(raw_value)
+    except json.JSONDecodeError:
+        logger.warning("[capture_upload_front_context_invalid] payload_type=%s", type(raw_value).__name__)
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 class LoginView(CompatEnvelopeAPIView):
@@ -204,6 +225,7 @@ class CaptureUploadView(CompatEnvelopeAPIView):
                     "client_id": {"type": "string"},
                     "customer_id": {"type": "string"},
                     "customer": {"type": "string"},
+                    "front_capture_context": {"type": "string"},
                     "file": {"type": "string", "format": "binary"},
                 },
                 "required": ["client_id", "file"],
@@ -235,6 +257,12 @@ class CaptureUploadView(CompatEnvelopeAPIView):
 
         validation = validate_capture_image(processed_bytes=processed_bytes)
         landmark_snapshot = extract_landmark_snapshot(processed_bytes=processed_bytes)
+        front_capture_context = _parse_front_capture_context(request)
+        capture_validation_snapshot = build_capture_validation_snapshot(
+            validation=validation,
+            landmark_snapshot=landmark_snapshot,
+            front_capture_context=front_capture_context,
+        )
         if settings.MIRRAI_PERSIST_CAPTURE_IMAGES:
             deidentified_bytes, privacy_snapshot = build_deidentified_capture(
                 processed_bytes=processed_bytes,
@@ -264,6 +292,11 @@ class CaptureUploadView(CompatEnvelopeAPIView):
                 "reason": "capture_images_not_persisted",
             }
 
+        privacy_snapshot = {
+            **privacy_snapshot,
+            "capture_validation": capture_validation_snapshot,
+        }
+
         record = create_legacy_capture_upload_record(
             client=client,
             original_path=original_path,
@@ -284,14 +317,56 @@ class CaptureUploadView(CompatEnvelopeAPIView):
         )
 
         logger.info(
-            "[capture_upload] client_id=%s status=%s storage_mode=%s has_required_assets=%s",
+            (
+                "[capture_upload] client_id=%s status=%s reason=%s face_count=%s "
+                "storage_mode=%s has_required_assets=%s"
+            ),
             client.id,
             validation["status"],
+            validation["reason_code"],
+            validation["face_count"],
             storage_snapshot["storage_mode"],
             storage_snapshot["has_required_capture_assets"],
         )
+        logger.info(
+            (
+                "[capture_upload_validation] client_id=%s brightness=%s sharpness=%s "
+                "face_area_ratio=%s thresholds=%s"
+            ),
+            client.id,
+            capture_validation_snapshot["diagnostics"].get("brightness"),
+            capture_validation_snapshot["diagnostics"].get("sharpness"),
+            capture_validation_snapshot["diagnostics"].get("face_area_ratio"),
+            capture_validation_snapshot["thresholds"],
+        )
+        if capture_validation_snapshot["front_capture_context_present"]:
+            logger.info(
+                (
+                    "[capture_upload_compare] client_id=%s front_all_valid=%s front_message_key=%s "
+                    "front_summary=%s backend_reason=%s backend_failed_after_front_ready=%s"
+                ),
+                client.id,
+                capture_validation_snapshot["front_all_valid"],
+                capture_validation_snapshot["front_message_key"],
+                capture_validation_snapshot["front_checklist_summary"],
+                capture_validation_snapshot["reason_code"],
+                capture_validation_snapshot["backend_failed_after_front_ready"],
+            )
 
         if not validation["is_valid"]:
+            logger.warning(
+                (
+                    "[capture_upload_failed] client_id=%s record_id=%s reason=%s face_count=%s "
+                    "landmark_face_count=%s brightness=%s sharpness=%s"
+                ),
+                client.id,
+                record.id,
+                validation["reason_code"],
+                validation["face_count"],
+                capture_validation_snapshot["landmark_face_count"],
+                capture_validation_snapshot["diagnostics"].get("brightness"),
+                capture_validation_snapshot["diagnostics"].get("sharpness"),
+            )
             return Response(
                 {
                     "status": "needs_retake",

--- a/app/management/commands/analyze_capture_upload_failures.py
+++ b/app/management/commands/analyze_capture_upload_failures.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 
 from django.core.management.base import BaseCommand
 from django.db import connection
@@ -36,6 +36,18 @@ class Command(BaseCommand):
         reason_counts: Counter[str] = Counter()
         failed_face_counts: Counter[str] = Counter()
         comparison_counts: Counter[str] = Counter()
+        reason_diagnostics: dict[str, dict] = defaultdict(
+            lambda: {
+                "count": 0,
+                "brightness_total": 0.0,
+                "brightness_count": 0,
+                "sharpness_total": 0.0,
+                "sharpness_count": 0,
+                "face_area_ratio_total": 0.0,
+                "face_area_ratio_count": 0,
+                "face_counts": Counter(),
+            }
+        )
 
         for row in rows:
             status = str(row.status or "UNKNOWN")
@@ -54,6 +66,23 @@ class Command(BaseCommand):
 
             if status == "NEEDS_RETAKE":
                 failed_face_counts[str(row.face_count if row.face_count is not None else "null")] += 1
+                diagnostics = validation_snapshot.get("diagnostics") if isinstance(validation_snapshot, dict) else None
+                stats = reason_diagnostics[reason_code]
+                stats["count"] += 1
+                stats["face_counts"][str(row.face_count if row.face_count is not None else "null")] += 1
+                if isinstance(diagnostics, dict):
+                    brightness = diagnostics.get("brightness")
+                    sharpness = diagnostics.get("sharpness")
+                    face_area_ratio = diagnostics.get("face_area_ratio")
+                    if isinstance(brightness, (int, float)):
+                        stats["brightness_total"] += float(brightness)
+                        stats["brightness_count"] += 1
+                    if isinstance(sharpness, (int, float)):
+                        stats["sharpness_total"] += float(sharpness)
+                        stats["sharpness_count"] += 1
+                    if isinstance(face_area_ratio, (int, float)):
+                        stats["face_area_ratio_total"] += float(face_area_ratio)
+                        stats["face_area_ratio_count"] += 1
 
             if isinstance(validation_snapshot, dict) and validation_snapshot:
                 if validation_snapshot.get("front_capture_context_present"):
@@ -77,6 +106,33 @@ class Command(BaseCommand):
         self.stdout.write("Retake face_count distribution:")
         for key, value in sorted(failed_face_counts.items(), key=lambda item: item[0]):
             self.stdout.write(f"  - {key}: {value}")
+
+        self.stdout.write("")
+        self.stdout.write("Retake diagnostics by reason:")
+        if reason_diagnostics:
+            for reason, stats in sorted(reason_diagnostics.items(), key=lambda item: (-item[1]["count"], item[0])):
+                brightness_avg = (
+                    round(stats["brightness_total"] / stats["brightness_count"], 2)
+                    if stats["brightness_count"]
+                    else None
+                )
+                sharpness_avg = (
+                    round(stats["sharpness_total"] / stats["sharpness_count"], 2)
+                    if stats["sharpness_count"]
+                    else None
+                )
+                face_area_ratio_avg = (
+                    round(stats["face_area_ratio_total"] / stats["face_area_ratio_count"], 4)
+                    if stats["face_area_ratio_count"]
+                    else None
+                )
+                self.stdout.write(
+                    f"  - {reason}: count={stats['count']}, "
+                    f"avg_brightness={brightness_avg}, avg_sharpness={sharpness_avg}, "
+                    f"avg_face_area_ratio={face_area_ratio_avg}, face_counts={dict(stats['face_counts'])}"
+                )
+        else:
+            self.stdout.write("  - no retake diagnostics captured yet")
 
         self.stdout.write("")
         self.stdout.write("Front-vs-back comparison signals:")

--- a/app/management/commands/analyze_capture_upload_failures.py
+++ b/app/management/commands/analyze_capture_upload_failures.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+from app.models_model_team import LegacyClientAnalysis
+from app.services.capture_validation import infer_capture_reason_code
+
+
+class Command(BaseCommand):
+    help = "Summarize capture/upload failure patterns and front-vs-back comparison signals."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=200,
+            help="Maximum number of latest capture-analysis rows to inspect. Default: 200",
+        )
+
+    def handle(self, *args, **options):
+        limit = max(int(options["limit"]), 1)
+        existing_tables = set(connection.introspection.table_names())
+        if LegacyClientAnalysis._meta.db_table not in existing_tables:
+            self.stdout.write(self.style.WARNING("client_analysis table is not available in the active database."))
+            return
+
+        rows = list(
+            LegacyClientAnalysis.objects.order_by("-updated_at_ts", "-analysis_id")[:limit]
+        )
+
+        status_counts: Counter[str] = Counter()
+        reason_counts: Counter[str] = Counter()
+        failed_face_counts: Counter[str] = Counter()
+        comparison_counts: Counter[str] = Counter()
+
+        for row in rows:
+            status = str(row.status or "UNKNOWN")
+            status_counts[status] += 1
+
+            privacy_snapshot = row.privacy_snapshot or {}
+            validation_snapshot = {}
+            if isinstance(privacy_snapshot, dict):
+                validation_snapshot = privacy_snapshot.get("capture_validation") or {}
+
+            reason_code = infer_capture_reason_code(
+                error_note=row.error_note,
+                privacy_snapshot=privacy_snapshot if isinstance(privacy_snapshot, dict) else None,
+            )
+            reason_counts[reason_code] += 1
+
+            if status == "NEEDS_RETAKE":
+                failed_face_counts[str(row.face_count if row.face_count is not None else "null")] += 1
+
+            if isinstance(validation_snapshot, dict) and validation_snapshot:
+                if validation_snapshot.get("front_capture_context_present"):
+                    comparison_counts["front_context_present"] += 1
+                if validation_snapshot.get("backend_failed_after_front_ready"):
+                    comparison_counts["backend_failed_after_front_ready"] += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Capture upload pattern summary (latest {len(rows)} rows)"))
+        self.stdout.write("")
+
+        self.stdout.write("Status counts:")
+        for key, value in sorted(status_counts.items()):
+            self.stdout.write(f"  - {key}: {value}")
+
+        self.stdout.write("")
+        self.stdout.write("Reason counts:")
+        for key, value in sorted(reason_counts.items(), key=lambda item: (-item[1], item[0])):
+            self.stdout.write(f"  - {key}: {value}")
+
+        self.stdout.write("")
+        self.stdout.write("Retake face_count distribution:")
+        for key, value in sorted(failed_face_counts.items(), key=lambda item: item[0]):
+            self.stdout.write(f"  - {key}: {value}")
+
+        self.stdout.write("")
+        self.stdout.write("Front-vs-back comparison signals:")
+        if comparison_counts:
+            for key, value in sorted(comparison_counts.items()):
+                self.stdout.write(f"  - {key}: {value}")
+        else:
+            self.stdout.write("  - none captured yet")

--- a/app/services/ai_facade.py
+++ b/app/services/ai_facade.py
@@ -425,6 +425,33 @@ def _build_preference_payload(survey_data: dict | None) -> dict:
     return payload
 
 
+def _build_runpod_preference_payload(survey_data: dict | None) -> dict:
+    survey_data = survey_data or {}
+    length = canonical_length(survey_data.get("target_length"))
+    mood = canonical_vibe(survey_data.get("target_vibe"))
+    hair_type = canonical_scalp(survey_data.get("scalp_type"))
+    budget = canonical_budget(survey_data.get("budget_range"))
+
+    mood_mapping = {
+        "natural": "natural",
+        "chic": "trendy",
+        "cute": "cute",
+        "elegant": "classic",
+    }
+
+    payload: dict[str, object] = {}
+    if length != "unknown":
+        payload["length"] = "medium" if length == "bob" else length
+    mapped_mood = mood_mapping.get(mood)
+    if mapped_mood:
+        payload["mood"] = [mapped_mood]
+    if hair_type in {"straight", "waved", "curly"}:
+        payload["hair_type"] = {"waved": "wavy"}.get(hair_type, hair_type)
+    if budget != "unknown":
+        payload["budget"] = {"mid": "medium"}.get(budget, budget)
+    return payload
+
+
 def _build_preference_text(survey_data: dict | None) -> str | None:
     survey_data = survey_data or {}
     parts = [
@@ -471,6 +498,42 @@ def _build_face_ratios(analysis_data: dict | None) -> dict | None:
     }
 
 
+def _match_runpod_recommendation(
+    *,
+    recommendations: list[dict],
+    index: int,
+    result: dict,
+) -> dict | None:
+    if index < len(recommendations) and isinstance(recommendations[index], dict):
+        return recommendations[index]
+
+    recommended_style = result.get("recommended_style") or {}
+    recommended_style_id = str(recommended_style.get("style_id") or "").strip()
+    recommended_style_name = str(recommended_style.get("style_name") or "").strip().lower()
+    if not recommended_style_id and not recommended_style_name:
+        return None
+
+    for recommendation in recommendations:
+        if not isinstance(recommendation, dict):
+            continue
+        candidate_id = str(recommendation.get("style_id") or "").strip()
+        candidate_name = str(recommendation.get("style_name") or "").strip().lower()
+        if recommended_style_id and candidate_id and candidate_id == recommended_style_id:
+            return recommendation
+        if recommended_style_name and candidate_name and candidate_name == recommended_style_name:
+            return recommendation
+    return None
+
+
+def _rag_context_excerpt(value: object, *, limit: int = 280) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3].rstrip() + "..."
+
+
 def _augment_items_with_runpod(
     *,
     items: list[dict],
@@ -491,7 +554,7 @@ def _augment_items_with_runpod(
         "top_k": min(len(items), 5),
         "return_base64": True,
     }
-    preference = _build_preference_payload(survey_data)
+    preference = _build_runpod_preference_payload(survey_data)
     preference_text = _build_preference_text(survey_data)
     if preference:
         runpod_payload["preference"] = preference
@@ -509,24 +572,49 @@ def _augment_items_with_runpod(
     if not isinstance(results, list) or not results:
         return items
 
+    recommendations = remote.get("recommendations")
+    if not isinstance(recommendations, list):
+        recommendations = []
+
+    rag_context_excerpt = _rag_context_excerpt(remote.get("rag_context"))
+    build_tag = str(remote.get("build_tag") or "").strip() or None
+    runpod_runtime = remote.get("runpod") if isinstance(remote.get("runpod"), dict) else {}
+
     augmented: list[dict] = []
     for index, item in enumerate(items):
         enriched = dict(item)
         if index < len(results):
             result = results[index] or {}
+            recommendation_meta = _match_runpod_recommendation(
+                recommendations=recommendations,
+                index=index,
+                result=result,
+            )
             image_base64 = result.get("image_base64")
             if image_base64:
                 data_url = f"data:image/png;base64,{image_base64}"
                 enriched["simulation_image_url"] = data_url
                 enriched["synthetic_image_url"] = data_url
             snapshot = dict(enriched.get("reasoning_snapshot") or {})
-            snapshot["runpod"] = {
+            runpod_snapshot = {
                 "provider": "runpod",
                 "clip_score": result.get("clip_score"),
                 "mask_used": result.get("mask_used"),
                 "elapsed_seconds": remote.get("elapsed_seconds"),
                 "recommended_style": result.get("recommended_style"),
+                "build_tag": build_tag,
+                "runtime": runpod_runtime,
+                "rag_context_excerpt": rag_context_excerpt,
             }
+            if recommendation_meta:
+                runpod_snapshot["recommendation"] = recommendation_meta
+                runpod_snapshot["face_shape_detected"] = recommendation_meta.get("face_shape_detected")
+                runpod_snapshot["golden_ratio_score"] = recommendation_meta.get("golden_ratio_score")
+                runpod_snapshot["face_shapes"] = recommendation_meta.get("face_shapes")
+                if recommendation_meta.get("description"):
+                    enriched["llm_explanation"] = enriched.get("llm_explanation") or recommendation_meta.get("description")
+                    enriched["style_description"] = enriched.get("style_description") or recommendation_meta.get("description")
+            snapshot["runpod"] = runpod_snapshot
             enriched["reasoning_snapshot"] = snapshot
         augmented.append(enriched)
     return augmented

--- a/app/services/ai_facade.py
+++ b/app/services/ai_facade.py
@@ -53,7 +53,11 @@ def _runpod_api_key() -> str:
 
 
 def _runpod_endpoint_id() -> str:
-    return os.environ.get("RUNPOD_ENDPOINT_ID", "").strip()
+    for env_name in ("RUNPOD_ENDPOINT_ID", "STABLE_DIFFUSION_ENDPOINT", "RUNPOD_TRENDS_ENDPOINT_ID"):
+        value = os.environ.get(env_name, "").strip()
+        if value:
+            return value
+    return ""
 
 
 def _runpod_health_timeout() -> tuple[int, int]:
@@ -73,14 +77,30 @@ def _runpod_enabled() -> bool:
     return bool(_runpod_api_key() and _runpod_endpoint_id())
 
 
+def _service_enabled() -> bool:
+    return bool(_service_base_url())
+
+
 def _ai_provider() -> str:
     configured = os.environ.get("MIRRAI_AI_PROVIDER", "").strip().lower()
-    if configured in {"runpod", "service", "local"}:
-        return configured
-    if _service_base_url():
-        return "service"
+    if configured == "runpod":
+        if _runpod_enabled():
+            return "runpod"
+        if _service_enabled():
+            return "service"
+        return "local"
+    if configured == "service":
+        if _service_enabled():
+            return "service"
+        if _runpod_enabled():
+            return "runpod"
+        return "local"
+    if configured == "local":
+        return "local"
     if _runpod_enabled():
         return "runpod"
+    if _service_enabled():
+        return "service"
     return "local"
 
 

--- a/app/services/capture_validation.py
+++ b/app/services/capture_validation.py
@@ -15,6 +15,95 @@ MIN_SHARPNESS = 45.0
 _FACE_CASCADE = cv2.CascadeClassifier(cv2.data.haarcascades + "haarcascade_frontalface_default.xml")
 
 
+def _detect_faces(
+    gray: np.ndarray,
+    *,
+    scale_factor: float,
+    min_neighbors: int,
+    min_size: tuple[int, int],
+):
+    return _FACE_CASCADE.detectMultiScale(
+        gray,
+        scaleFactor=scale_factor,
+        minNeighbors=min_neighbors,
+        minSize=min_size,
+    )
+
+
+def _iou(face_a, face_b) -> float:
+    ax, ay, aw, ah = [int(value) for value in face_a]
+    bx, by, bw, bh = [int(value) for value in face_b]
+    a_right = ax + aw
+    a_bottom = ay + ah
+    b_right = bx + bw
+    b_bottom = by + bh
+
+    inter_left = max(ax, bx)
+    inter_top = max(ay, by)
+    inter_right = min(a_right, b_right)
+    inter_bottom = min(a_bottom, b_bottom)
+    if inter_right <= inter_left or inter_bottom <= inter_top:
+        return 0.0
+
+    intersection = float((inter_right - inter_left) * (inter_bottom - inter_top))
+    union = float((aw * ah) + (bw * bh) - intersection)
+    if union <= 0:
+        return 0.0
+    return intersection / union
+
+
+def _dedupe_faces(faces, *, iou_threshold: float = 0.35) -> list[tuple[int, int, int, int]]:
+    candidates = [tuple(int(value) for value in face) for face in faces]
+    candidates.sort(key=lambda row: row[2] * row[3], reverse=True)
+    deduped: list[tuple[int, int, int, int]] = []
+    for face in candidates:
+        if any(_iou(face, existing) >= iou_threshold for existing in deduped):
+            continue
+        deduped.append(face)
+    return deduped
+
+
+def _select_candidate_faces(gray: np.ndarray) -> list[tuple[int, int, int, int]]:
+    primary_faces = _dedupe_faces(
+        _detect_faces(
+            gray,
+            scale_factor=1.1,
+            min_neighbors=5,
+            min_size=(80, 80),
+        )
+    )
+    if len(primary_faces) == 1:
+        return primary_faces
+
+    # Front already filters alignment and position aggressively, so backend
+    # gives Haar one more chance before forcing retake on count mismatches.
+    if len(primary_faces) == 0:
+        equalized = cv2.equalizeHist(gray)
+        relaxed_faces = _dedupe_faces(
+            _detect_faces(
+                equalized,
+                scale_factor=1.05,
+                min_neighbors=4,
+                min_size=(72, 72),
+            )
+        )
+        if len(relaxed_faces) == 1:
+            return relaxed_faces
+        return relaxed_faces
+
+    stricter_faces = _dedupe_faces(
+        _detect_faces(
+            gray,
+            scale_factor=1.12,
+            min_neighbors=7,
+            min_size=(96, 96),
+        )
+    )
+    if len(stricter_faces) == 1:
+        return stricter_faces
+    return primary_faces
+
+
 def _validation_thresholds() -> dict:
     return {
         "min_face_size_ratio": MIN_FACE_SIZE_RATIO,
@@ -164,12 +253,7 @@ def validate_capture_image(*, processed_bytes: bytes) -> dict:
     brightness = float(gray.mean())
     sharpness = float(cv2.Laplacian(gray, cv2.CV_64F).var())
     height, width = gray.shape[:2]
-    faces = _FACE_CASCADE.detectMultiScale(
-        gray,
-        scaleFactor=1.1,
-        minNeighbors=5,
-        minSize=(80, 80),
-    )
+    faces = _select_candidate_faces(gray)
     face_count = len(faces)
 
     if brightness < MIN_BRIGHTNESS:

--- a/app/services/capture_validation.py
+++ b/app/services/capture_validation.py
@@ -15,6 +15,119 @@ MIN_SHARPNESS = 45.0
 _FACE_CASCADE = cv2.CascadeClassifier(cv2.data.haarcascades + "haarcascade_frontalface_default.xml")
 
 
+def _validation_thresholds() -> dict:
+    return {
+        "min_face_size_ratio": MIN_FACE_SIZE_RATIO,
+        "min_brightness": MIN_BRIGHTNESS,
+        "max_brightness": MAX_BRIGHTNESS,
+        "min_sharpness": MIN_SHARPNESS,
+    }
+
+
+def _base_validation_payload(
+    *,
+    is_valid: bool,
+    status: str,
+    face_count: int,
+    reason_code: str,
+    message: str,
+    brightness: float | None = None,
+    sharpness: float | None = None,
+    image_width: int | None = None,
+    image_height: int | None = None,
+    face_area_ratio: float | None = None,
+) -> dict:
+    return {
+        "is_valid": is_valid,
+        "status": status,
+        "face_count": face_count,
+        "reason_code": reason_code,
+        "message": message,
+        "diagnostics": {
+            "brightness": (None if brightness is None else round(float(brightness), 2)),
+            "sharpness": (None if sharpness is None else round(float(sharpness), 2)),
+            "image_width": image_width,
+            "image_height": image_height,
+            "face_area_ratio": (None if face_area_ratio is None else round(float(face_area_ratio), 4)),
+        },
+        "thresholds": _validation_thresholds(),
+    }
+
+
+def build_capture_validation_snapshot(
+    *,
+    validation: dict,
+    landmark_snapshot: dict | None = None,
+    front_capture_context: dict | None = None,
+) -> dict:
+    diagnostics = dict(validation.get("diagnostics") or {})
+    thresholds = dict(validation.get("thresholds") or _validation_thresholds())
+    front_context = front_capture_context if isinstance(front_capture_context, dict) else None
+
+    front_all_valid = None
+    front_message_key = None
+    front_checklist_summary = None
+    if front_context is not None:
+        if "all_valid" in front_context:
+            front_all_valid = bool(front_context.get("all_valid"))
+        front_message_key = front_context.get("message_key")
+        front_checklist_summary = front_context.get("checklist_summary") or front_context.get("summary")
+
+    return {
+        "status": validation.get("status"),
+        "is_valid": bool(validation.get("is_valid")),
+        "reason_code": validation.get("reason_code"),
+        "face_count": validation.get("face_count"),
+        "message": validation.get("message"),
+        "diagnostics": diagnostics,
+        "thresholds": thresholds,
+        "landmark_face_count": (
+            (landmark_snapshot or {}).get("face_count")
+            if isinstance(landmark_snapshot, dict)
+            else None
+        ),
+        "landmark_quality_reason": (
+            ((landmark_snapshot or {}).get("quality") or {}).get("reason")
+            if isinstance(landmark_snapshot, dict)
+            else None
+        ),
+        "front_capture_context_present": front_context is not None,
+        "front_all_valid": front_all_valid,
+        "front_message_key": front_message_key,
+        "front_checklist_summary": front_checklist_summary,
+        "backend_failed_after_front_ready": bool(front_all_valid is True and not validation.get("is_valid", False)),
+        "front_capture_context": front_context,
+    }
+
+
+def infer_capture_reason_code(*, error_note: str | None, privacy_snapshot: dict | None = None) -> str:
+    if isinstance(privacy_snapshot, dict):
+        validation_snapshot = privacy_snapshot.get("capture_validation") or {}
+        reason_code = validation_snapshot.get("reason_code")
+        if reason_code:
+            return str(reason_code)
+
+    message = (error_note or "").strip()
+    if not message:
+        return "unknown"
+
+    if "여러 얼굴" in message:
+        return "multiple_faces_detected"
+    if "얼굴이 감지되지" in message:
+        return "no_face_detected"
+    if "너무 멀" in message:
+        return "face_too_small"
+    if "흐릿" in message:
+        return "too_blurry"
+    if "너무 밝" in message:
+        return "too_bright"
+    if "너무 어두" in message:
+        return "too_dark"
+    if "processed" in message.lower():
+        return "decode_failed"
+    return "unknown"
+
+
 def sanitize_original_upload(*, image: Image.Image, original_ext: str) -> tuple[bytes, str]:
     ext = original_ext.lower()
     target_format = "JPEG"
@@ -39,17 +152,18 @@ def validate_capture_image(*, processed_bytes: bytes) -> dict:
     image_array = np.frombuffer(processed_bytes, dtype=np.uint8)
     decoded = cv2.imdecode(image_array, cv2.IMREAD_COLOR)
     if decoded is None:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": 0,
-            "reason_code": "too_dark",
-            "message": "The image could not be processed. Please take the photo again.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=0,
+            reason_code="decode_failed",
+            message="The image could not be processed. Please take the photo again.",
+        )
 
     gray = cv2.cvtColor(decoded, cv2.COLOR_BGR2GRAY)
     brightness = float(gray.mean())
     sharpness = float(cv2.Laplacian(gray, cv2.CV_64F).var())
+    height, width = gray.shape[:2]
     faces = _FACE_CASCADE.detectMultiScale(
         gray,
         scaleFactor=1.1,
@@ -59,62 +173,92 @@ def validate_capture_image(*, processed_bytes: bytes) -> dict:
     face_count = len(faces)
 
     if brightness < MIN_BRIGHTNESS:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": face_count,
-            "reason_code": "too_dark",
-            "message": "이미지가 너무 어두워 얼굴 인식이 어렵습니다. 밝은 곳에서 다시 촬영해 주세요.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=face_count,
+            reason_code="too_dark",
+            message="이미지가 너무 어두워 얼굴 인식이 어렵습니다. 밝은 곳에서 다시 촬영해 주세요.",
+            brightness=brightness,
+            sharpness=sharpness,
+            image_width=width,
+            image_height=height,
+        )
     if brightness > MAX_BRIGHTNESS:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": face_count,
-            "reason_code": "too_bright",
-            "message": "이미지가 너무 밝아 얼굴 인식이 어렵습니다. 조명을 조절한 뒤 다시 촬영해 주세요.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=face_count,
+            reason_code="too_bright",
+            message="이미지가 너무 밝아 얼굴 인식이 어렵습니다. 조명을 조절한 뒤 다시 촬영해 주세요.",
+            brightness=brightness,
+            sharpness=sharpness,
+            image_width=width,
+            image_height=height,
+        )
     if face_count == 0:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": 0,
-            "reason_code": "no_face_detected",
-            "message": "얼굴이 감지되지 않았습니다. 정면을 바라보고 다시 촬영해 주세요.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=0,
+            reason_code="no_face_detected",
+            message="얼굴이 감지되지 않았습니다. 정면을 바라보고 다시 촬영해 주세요.",
+            brightness=brightness,
+            sharpness=sharpness,
+            image_width=width,
+            image_height=height,
+        )
     if face_count > 1:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": face_count,
-            "reason_code": "multiple_faces_detected",
-            "message": "여러 얼굴이 감지되었습니다. 한 명만 화면에 나오도록 다시 촬영해 주세요.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=face_count,
+            reason_code="multiple_faces_detected",
+            message="여러 얼굴이 감지되었습니다. 한 명만 화면에 나오도록 다시 촬영해 주세요.",
+            brightness=brightness,
+            sharpness=sharpness,
+            image_width=width,
+            image_height=height,
+        )
 
-    height, width = gray.shape[:2]
     x, y, face_width, face_height = faces[0]
     face_area_ratio = float(face_width * face_height) / float(width * height)
     if face_area_ratio < MIN_FACE_SIZE_RATIO:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": face_count,
-            "reason_code": "face_too_small",
-            "message": "얼굴이 너무 멀어요. 카메라에 조금 더 가까이 와서 다시 촬영해 주세요.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=face_count,
+            reason_code="face_too_small",
+            message="얼굴이 너무 멀어요. 카메라에 조금 더 가까이 와서 다시 촬영해 주세요.",
+            brightness=brightness,
+            sharpness=sharpness,
+            image_width=width,
+            image_height=height,
+            face_area_ratio=face_area_ratio,
+        )
     if sharpness < MIN_SHARPNESS:
-        return {
-            "is_valid": False,
-            "status": "NEEDS_RETAKE",
-            "face_count": face_count,
-            "reason_code": "too_blurry",
-            "message": "이미지가 흐릿해 정확한 분석이 어렵습니다. 잠시 멈춘 상태에서 다시 촬영해 주세요.",
-        }
+        return _base_validation_payload(
+            is_valid=False,
+            status="NEEDS_RETAKE",
+            face_count=face_count,
+            reason_code="too_blurry",
+            message="이미지가 흐릿해 정확한 분석이 어렵습니다. 잠시 멈춘 상태에서 다시 촬영해 주세요.",
+            brightness=brightness,
+            sharpness=sharpness,
+            image_width=width,
+            image_height=height,
+            face_area_ratio=face_area_ratio,
+        )
 
-    return {
-        "is_valid": True,
-        "status": "PENDING",
-        "face_count": face_count,
-        "reason_code": "ok",
-        "message": "얼굴 인식이 완료되었습니다. 분석을 진행합니다.",
-    }
+    return _base_validation_payload(
+        is_valid=True,
+        status="PENDING",
+        face_count=face_count,
+        reason_code="ok",
+        message="얼굴 인식이 완료되었습니다. 분석을 진행합니다.",
+        brightness=brightness,
+        sharpness=sharpness,
+        image_width=width,
+        image_height=height,
+        face_area_ratio=face_area_ratio,
+    )

--- a/app/tests/test_ai_facade.py
+++ b/app/tests/test_ai_facade.py
@@ -1,0 +1,303 @@
+import json
+import os
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from fastapi.testclient import TestClient
+
+import main as internal_ai_main
+from app.services import ai_facade
+from app.services.ai_facade import (
+    generate_recommendation_batch,
+    get_ai_health,
+    simulate_face_analysis,
+)
+
+
+class _MockResponse:
+    def __init__(self, *, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+
+    @property
+    def ok(self):
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise RuntimeError(f"status={self.status_code}")
+
+
+class AiFacadeContractTests(SimpleTestCase):
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_AI_PROVIDER": "service",
+            "MIRRAI_AI_SERVICE_URL": "https://mirrai.shop",
+            "MIRRAI_INTERNAL_API_TOKEN": "secret-token",
+            "MIRRAI_AI_API_VERSION": "2026-04-06",
+            "RUNPOD_API_KEY": "legacy-runpod-key",
+            "RUNPOD_ENDPOINT_ID": "legacy-runpod-endpoint",
+        },
+        clear=False,
+    )
+    @patch("app.services.ai_facade.requests.request")
+    def test_get_ai_health_prefers_internal_service_contract(self, mock_request):
+        mock_request.return_value = _MockResponse(
+            payload={
+                "status": "success",
+                "schema_version": "2026-04-06",
+                "response_version": "1.2.0",
+                "request_id": "req-health",
+                "processing_time_ms": 12,
+                "data": {
+                    "role": "ai-microservice",
+                    "build_version": "2026.04.06",
+                    "model_version": "model-v2",
+                    "uptime_seconds": 321,
+                },
+            }
+        )
+
+        payload = get_ai_health(use_cache=False)
+
+        self.assertEqual(payload["mode"], "service")
+        self.assertEqual(payload["status"], "online")
+        self.assertEqual(payload["message"], "ai-microservice")
+        self.assertEqual(payload["build_version"], "2026.04.06")
+        self.assertEqual(payload["model_version"], "model-v2")
+        self.assertEqual(payload["request_id"], "req-health")
+
+        _, kwargs = mock_request.call_args
+        self.assertEqual(kwargs["method"], "GET")
+        self.assertTrue(kwargs["url"].endswith("/internal/health"))
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret-token")
+        self.assertEqual(kwargs["headers"]["X-MirrAI-API-Version"], "2026-04-06")
+
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_AI_PROVIDER": "service",
+            "MIRRAI_AI_SERVICE_URL": "https://mirrai.shop",
+            "MIRRAI_INTERNAL_API_TOKEN": "secret-token",
+        },
+        clear=False,
+    )
+    @patch("app.services.ai_facade.requests.request")
+    def test_simulate_face_analysis_unwraps_service_data(self, mock_request):
+        mock_request.return_value = _MockResponse(
+            payload={
+                "status": "success",
+                "schema_version": "2026-04-06",
+                "response_version": "1.2.0",
+                "request_id": "req-face",
+                "processing_time_ms": 28,
+                "data": {
+                    "face_shape": "Round",
+                    "golden_ratio_score": 0.88,
+                    "face_bbox": {"x": 1, "y": 2, "width": 3, "height": 4},
+                    "visualization": {"image_url": "https://cdn.example.com/face.png"},
+                },
+            }
+        )
+
+        payload = simulate_face_analysis(image_url="https://cdn.example.com/original.png")
+
+        self.assertEqual(payload["face_shape"], "Round")
+        self.assertEqual(payload["golden_ratio_score"], 0.88)
+        self.assertEqual(payload["face_bbox"]["width"], 3)
+        self.assertEqual(payload["image_url"], "https://cdn.example.com/face.png")
+        self.assertEqual(payload["response_meta"]["request_id"], "req-face")
+
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_AI_PROVIDER": "service",
+            "MIRRAI_AI_SERVICE_URL": "https://mirrai.shop",
+            "MIRRAI_INTERNAL_API_TOKEN": "secret-token",
+        },
+        clear=False,
+    )
+    @patch("app.services.ai_facade.requests.request")
+    def test_generate_recommendation_batch_accepts_partial_success_contract(self, mock_request):
+        mock_request.return_value = _MockResponse(
+            payload={
+                "status": "partial_success",
+                "schema_version": "2026-04-06",
+                "response_version": "1.2.0",
+                "request_id": "req-sim",
+                "processing_time_ms": 54,
+                "partial_failures": [{"style_id": 99, "message": "simulation timeout"}],
+                "data": {
+                    "items": [
+                        {
+                            "style_id": 1,
+                            "style_name": "Layered Cut",
+                            "rank": 1,
+                            "score": 0.91,
+                            "simulation_image_url": "https://cdn.example.com/sim.png",
+                            "reasoning_snapshot": {"summary": "Works well with the face shape and requested mood."},
+                        }
+                    ]
+                },
+            }
+        )
+
+        items = generate_recommendation_batch(
+            client_id=1,
+            survey_data={"target_length": "medium"},
+            analysis_data={"face_shape": "Oval", "golden_ratio_score": 0.91},
+        )
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["style_name"], "Layered Cut")
+        self.assertEqual(items[0]["match_score"], 0.91)
+        self.assertEqual(items[0]["synthetic_image_url"], "https://cdn.example.com/sim.png")
+        self.assertEqual(items[0]["reasoning_snapshot"]["service_status"], "partial_success")
+        self.assertEqual(items[0]["reasoning_snapshot"]["partial_failures"][0]["style_id"], 99)
+        self.assertEqual(items[0]["response_meta"]["request_id"], "req-sim")
+
+
+class AiFacadeRunpodDirectTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        ai_facade._AI_HEALTH_CACHE["expires_at"] = 0.0
+        ai_facade._AI_HEALTH_CACHE["payload"] = None
+
+    @patch.dict(
+        os.environ,
+        {
+            "RUNPOD_API_KEY": "runpod-key",
+            "RUNPOD_ENDPOINT_ID": "",
+            "STABLE_DIFFUSION_ENDPOINT": "stable-endpoint",
+            "RUNPOD_TRENDS_ENDPOINT_ID": "",
+        },
+        clear=False,
+    )
+    def test_runpod_endpoint_id_falls_back_to_stable_diffusion_endpoint(self):
+        self.assertEqual(ai_facade._runpod_endpoint_id(), "stable-endpoint")
+        self.assertTrue(ai_facade._runpod_enabled())
+
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_AI_PROVIDER": "service",
+            "MIRRAI_AI_SERVICE_URL": "",
+            "RUNPOD_API_KEY": "runpod-key",
+            "RUNPOD_TRENDS_ENDPOINT_ID": "trend-endpoint",
+        },
+        clear=False,
+    )
+    def test_service_provider_falls_back_to_runpod_when_service_is_missing(self):
+        self.assertEqual(ai_facade._ai_provider(), "runpod")
+
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_AI_PROVIDER": "service",
+            "MIRRAI_AI_SERVICE_URL": "",
+            "RUNPOD_API_KEY": "runpod-key",
+            "RUNPOD_ENDPOINT_ID": "",
+            "STABLE_DIFFUSION_ENDPOINT": "stable-endpoint",
+            "RUNPOD_TRENDS_ENDPOINT_ID": "",
+        },
+        clear=False,
+    )
+    @patch("app.services.ai_facade.requests.post")
+    def test_health_check_uses_runpod_when_service_is_not_configured(self, mock_post):
+        mock_post.return_value = _MockResponse(
+            payload={
+                "output": {
+                    "status": "COMPLETED",
+                    "cuda": {"device": "runpod-gpu"},
+                }
+            }
+        )
+
+        payload = get_ai_health(use_cache=False)
+
+        self.assertEqual(payload["mode"], "runpod")
+        self.assertEqual(payload["status"], "online")
+        self.assertEqual(payload["message"], "runpod-gpu")
+
+
+class InternalAiServiceContractTests(SimpleTestCase):
+    def setUp(self):
+        super().setUp()
+        internal_ai_main.app.openapi_schema = None
+
+    @patch.dict(os.environ, {"MIRRAI_INTERNAL_API_TOKEN": "internal-secret"}, clear=False)
+    def test_internal_health_requires_auth_when_token_is_configured(self):
+        with TestClient(internal_ai_main.app) as client:
+            response = client.get("/internal/health")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "error")
+        self.assertEqual(payload["error_code"], "unauthorized")
+
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_INTERNAL_API_TOKEN": "internal-secret",
+            "MIRRAI_AI_BUILD_VERSION": "2026.04.06",
+            "MIRRAI_MODEL_VERSION": "model-v2",
+        },
+        clear=False,
+    )
+    def test_internal_health_returns_contract_envelope(self):
+        with TestClient(internal_ai_main.app) as client:
+            response = client.get(
+                "/internal/health",
+                headers={
+                    "Authorization": "Bearer internal-secret",
+                    "X-MirrAI-API-Version": "2026-04-06",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(payload["schema_version"], "2026-04-06")
+        self.assertEqual(payload["response_version"], "1.2.0")
+        self.assertEqual(payload["data"]["role"], "ai-microservice")
+        self.assertEqual(payload["data"]["build_version"], "2026.04.06")
+        self.assertEqual(payload["data"]["model_version"], "model-v2")
+        self.assertEqual(payload["data"]["requested_api_version"], "2026-04-06")
+
+    @patch.dict(os.environ, {"MIRRAI_INTERNAL_API_TOKEN": "internal-secret"}, clear=False)
+    @patch("main.score_recommendations")
+    def test_generate_simulations_returns_contract_envelope(self, mock_score_recommendations):
+        mock_score_recommendations.return_value = [
+            {
+                "style_id": 7,
+                "style_name": "Hush Cut",
+                "rank": 1,
+                "score": 0.95,
+                "simulation_image_url": "https://cdn.example.com/hush.png",
+                "reasoning_snapshot": {"summary": "The light texture and volume balance the profile well."},
+            }
+        ]
+
+        with TestClient(internal_ai_main.app) as client:
+            response = client.post(
+                "/internal/generate-simulations",
+                headers={"Authorization": "Bearer internal-secret"},
+                json={
+                    "client_id": 1,
+                    "survey_data": {"target_length": "medium"},
+                    "analysis_data": {"face_shape": "Oval", "golden_ratio_score": 0.92},
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(payload["data"]["items"][0]["style_id"], 7)
+        self.assertEqual(payload["data"]["items"][0]["style_name"], "Hush Cut")

--- a/app/tests/test_ai_facade.py
+++ b/app/tests/test_ai_facade.py
@@ -226,6 +226,95 @@ class AiFacadeRunpodDirectTests(SimpleTestCase):
         self.assertEqual(payload["status"], "online")
         self.assertEqual(payload["message"], "runpod-gpu")
 
+    @patch.dict(
+        os.environ,
+        {
+            "MIRRAI_AI_PROVIDER": "runpod",
+            "RUNPOD_API_KEY": "runpod-key",
+            "RUNPOD_ENDPOINT_ID": "stable-endpoint",
+        },
+        clear=False,
+    )
+    @patch("app.services.ai_facade.requests.post")
+    @patch("app.services.ai_facade.score_recommendations")
+    def test_runpod_recommendation_metadata_is_attached_to_reasoning_snapshot(self, mock_score_recommendations, mock_post):
+        mock_score_recommendations.return_value = [
+            {
+                "style_id": 201,
+                "style_name": "Side-Parted Lob",
+                "style_description": "",
+                "keywords": ["lob"],
+                "match_score": 0.77,
+                "rank": 0,
+                "reasoning_snapshot": {"summary": "local summary"},
+            }
+        ]
+        mock_post.return_value = _MockResponse(
+            payload={
+                "output": {
+                    "results": [
+                        {
+                            "rank": 0,
+                            "seed": 42,
+                            "clip_score": 0.298,
+                            "mask_used": "sam2",
+                            "image_base64": "ZmFrZS1pbWFnZQ==",
+                            "recommended_style": {
+                                "style_id": "shaggy-midi",
+                                "style_name": "Shaggy Midi Cut",
+                                "recommendation_score": 0.8437,
+                            },
+                        }
+                    ],
+                    "recommendations": [
+                        {
+                            "rank": 0,
+                            "style_id": "shaggy-midi",
+                            "style_name": "Shaggy Midi Cut",
+                            "score": 0.8437,
+                            "description": "Mid-length shag with crown texture.",
+                            "face_shape_detected": "oval",
+                            "golden_ratio_score": 0.649,
+                            "face_shapes": ["round", "oval", "oblong"],
+                        }
+                    ],
+                    "rag_context": "[자료 1] 제목: shaggy midi",
+                    "elapsed_seconds": 58.7,
+                    "build_tag": "build-2026-04-06",
+                    "runpod": {"endpoint_id": "stable-endpoint"},
+                }
+            }
+        )
+
+        items = generate_recommendation_batch(
+            client_id=1,
+            survey_data={"target_length": "medium", "target_vibe": "chic"},
+            analysis_data={
+                "face_shape": "Oval",
+                "golden_ratio_score": 0.91,
+                "image_url": "https://cdn.example.com/original.png",
+                "landmark_snapshot": {
+                    "face_bbox": {"width": 100, "height": 140},
+                    "landmarks": {
+                        "left_eye": {"point": {"x": 20, "y": 40}},
+                        "right_eye": {"point": {"x": 80, "y": 40}},
+                        "mouth_center": {"point": {"x": 50, "y": 90}},
+                        "chin_center": {"point": {"x": 50, "y": 130}},
+                    },
+                },
+            },
+        )
+
+        self.assertEqual(len(items), 1)
+        self.assertTrue(items[0]["simulation_image_url"].startswith("data:image/png;base64,"))
+        self.assertEqual(items[0]["llm_explanation"], "Mid-length shag with crown texture.")
+        snapshot = items[0]["reasoning_snapshot"]["runpod"]
+        self.assertEqual(snapshot["build_tag"], "build-2026-04-06")
+        self.assertEqual(snapshot["face_shape_detected"], "oval")
+        self.assertEqual(snapshot["golden_ratio_score"], 0.649)
+        self.assertEqual(snapshot["runtime"]["endpoint_id"], "stable-endpoint")
+        self.assertIn("shaggy midi", snapshot["rag_context_excerpt"].lower())
+
 
 class InternalAiServiceContractTests(SimpleTestCase):
     def setUp(self):

--- a/app/tests/test_designer_diagnosis_card.py
+++ b/app/tests/test_designer_diagnosis_card.py
@@ -461,3 +461,36 @@ class DesignerDiagnosisCardFlowTests(TestCase):
         self.assertIn("Reason counts:", output)
         self.assertIn("no_face_detected", output)
         self.assertIn("backend_failed_after_front_ready", output)
+
+    def test_capture_validation_accepts_equalized_single_face_fallback(self):
+        from app.services import capture_validation
+
+        image_file = self._build_test_upload_file()
+        image_bytes = image_file.read()
+
+        with patch.object(capture_validation, "MIN_SHARPNESS", 0), patch(
+            "app.services.capture_validation._detect_faces",
+            side_effect=[[], [(12, 18, 180, 190)]],
+        ):
+            result = capture_validation.validate_capture_image(processed_bytes=image_bytes)
+
+        self.assertTrue(result["is_valid"])
+        self.assertEqual(result["face_count"], 1)
+        self.assertEqual(result["reason_code"], "ok")
+
+    def test_capture_validation_accepts_stricter_single_face_resolution_for_multiple_faces(self):
+        from app.services import capture_validation
+
+        image_file = self._build_test_upload_file()
+        image_bytes = image_file.read()
+
+        with patch.object(capture_validation, "MIN_SHARPNESS", 0), patch(
+            "app.services.capture_validation._detect_faces",
+            side_effect=[[(10, 10, 180, 180), (28, 24, 170, 170)], [(14, 12, 182, 184)]],
+        ):
+            result = capture_validation.validate_capture_image(processed_bytes=image_bytes)
+
+        self.assertTrue(result["is_valid"])
+        self.assertEqual(result["face_count"], 1)
+        self.assertEqual(result["reason_code"], "ok")
+

--- a/app/tests/test_designer_diagnosis_card.py
+++ b/app/tests/test_designer_diagnosis_card.py
@@ -1,12 +1,16 @@
+import io
 import json
 from unittest.mock import patch
 
 from django.core.management import call_command
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import connection
 from django.test import TestCase, override_settings
 
 from app.models_django import ClientProfileNote, DesignerDiagnosisCard
-from app.models_model_team import LegacyClient
+from PIL import Image
+
+from app.models_model_team import LegacyClient, LegacyClientAnalysis
 from app.services.model_team_bridge import (
     get_admin_by_phone,
     get_legacy_active_consultation_items,
@@ -64,6 +68,11 @@ class DesignerDiagnosisCardFlowTests(TestCase):
         session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
         session.save()
         return designer
+
+    def _build_test_upload_file(self, *, size=(400, 400), color=(128, 128, 128), name="capture.jpg"):
+        buffer = io.BytesIO()
+        Image.new("RGB", size, color).save(buffer, format="JPEG")
+        return SimpleUploadedFile(name, buffer.getvalue(), content_type="image/jpeg")
 
     def test_legacy_customer_detail_exposes_session_status_and_empty_payloads(self):
         self._login_shop_session()
@@ -377,3 +386,78 @@ class DesignerDiagnosisCardFlowTests(TestCase):
 
         self.assertIsNotNone(row)
         self.assertEqual(row[0], "고객은 볼륨은 원하지만 끝선 손상 케어를 우선 원합니다.")
+
+    def test_capture_upload_failure_stores_diagnostics_and_reason_code(self):
+        self._login_shop_session()
+
+        response = self.client.post(
+            "/api/v1/capture/upload/",
+            data={
+                "customer_id": str(self.client_id),
+                "file": self._build_test_upload_file(),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "needs_retake")
+        self.assertEqual(payload["reason_code"], "no_face_detected")
+
+        diagnostics = payload["privacy_snapshot"]["capture_validation"]["diagnostics"]
+        thresholds = payload["privacy_snapshot"]["capture_validation"]["thresholds"]
+        self.assertIn("brightness", diagnostics)
+        self.assertIn("sharpness", diagnostics)
+        self.assertIn("min_brightness", thresholds)
+        self.assertIn("min_sharpness", thresholds)
+
+        record = LegacyClientAnalysis.objects.get(analysis_id=payload["record_id"])
+        validation_snapshot = record.privacy_snapshot["capture_validation"]
+        self.assertEqual(validation_snapshot["reason_code"], "no_face_detected")
+        self.assertFalse(validation_snapshot["front_capture_context_present"])
+
+    def test_capture_upload_failure_marks_backend_failed_after_front_ready_when_context_sent(self):
+        self._login_shop_session()
+
+        response = self.client.post(
+            "/api/v1/capture/upload/",
+            data={
+                "customer_id": str(self.client_id),
+                "front_capture_context": json.dumps(
+                    {
+                        "all_valid": True,
+                        "message_key": "ready_to_capture",
+                        "checklist_summary": "5/5 pass",
+                    }
+                ),
+                "file": self._build_test_upload_file(name="capture-front-context.jpg"),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        validation_snapshot = payload["privacy_snapshot"]["capture_validation"]
+        self.assertTrue(validation_snapshot["front_capture_context_present"])
+        self.assertTrue(validation_snapshot["front_all_valid"])
+        self.assertTrue(validation_snapshot["backend_failed_after_front_ready"])
+        self.assertEqual(validation_snapshot["front_message_key"], "ready_to_capture")
+
+    def test_capture_failure_analysis_command_summarizes_reason_codes(self):
+        self._login_shop_session()
+
+        self.client.post(
+            "/api/v1/capture/upload/",
+            data={
+                "customer_id": str(self.client_id),
+                "front_capture_context": json.dumps({"all_valid": True, "message_key": "ready_to_capture"}),
+                "file": self._build_test_upload_file(name="capture-summary.jpg"),
+            },
+        )
+
+        stdout = io.StringIO()
+        call_command("analyze_capture_upload_failures", "--limit", "20", stdout=stdout)
+        output = stdout.getvalue()
+
+        self.assertIn("Capture upload pattern summary", output)
+        self.assertIn("Reason counts:", output)
+        self.assertIn("no_face_detected", output)
+        self.assertIn("backend_failed_after_front_ready", output)

--- a/docs/runpod_direct_b_refactor_report_0406_ver1.md
+++ b/docs/runpod_direct_b_refactor_report_0406_ver1.md
@@ -1,0 +1,82 @@
+# RunPod Direct B안 개편 보고서 0406 ver_1
+
+## 목적
+
+- A안의 안전한 기준선을 유지한 상태에서, backend가 RunPod direct 응답을 더 적극적으로 활용하도록 개편했다.
+- 이번 B안은 독립 얼굴 분석 API를 새로 만들지 않고, 추천 기반 RunPod 응답에 포함된 메타를 backend 추천 결과에 보존하는 방향이다.
+
+## A안과의 차이
+
+- A안
+  - RunPod endpoint/env 해석 정리
+  - `MIRRAI_AI_PROVIDER=service`라도 service URL이 비어 있으면 runpod fallback
+  - health check와 추천 이미지 생성만 보수적으로 활성화
+  - 독립 얼굴 분석은 기존 local/internal fallback 유지
+
+- B안
+  - AI팀 `handler_sd.py` / `README.md` 기준 RunPod 응답 메타를 backend가 실제로 읽도록 확장
+  - `results[]` 외에 `recommendations[]`, `rag_context`, `build_tag`, `runpod` 메타를 reasoning snapshot에 보존
+  - backend 추천 카드가 RunPod 추천 근거와 얼굴 메타를 같이 들고 있게 정리
+
+## 반영 내용
+
+### 1. RunPod preference payload를 direct 계약에 맞게 보정
+
+- `app/services/ai_facade.py`
+- backend의 canonical 선호값을 RunPod README 기준 preference 구조로 다시 매핑했다.
+- 예시:
+  - `chic -> trendy`
+  - `elegant -> classic`
+  - `waved -> wavy`
+  - `mid -> medium`
+
+### 2. RunPod 추천 응답 메타를 reasoning snapshot에 적재
+
+- `app/services/ai_facade.py`
+- RunPod 응답에서 아래 값을 추출해 각 recommendation item의 `reasoning_snapshot.runpod`에 저장한다.
+  - `clip_score`
+  - `mask_used`
+  - `elapsed_seconds`
+  - `recommended_style`
+  - `build_tag`
+  - `runpod`
+  - `rag_context_excerpt`
+  - `recommendations[]`에서 찾은 `face_shape_detected`
+  - `recommendations[]`에서 찾은 `golden_ratio_score`
+  - `recommendations[]`에서 찾은 `face_shapes`
+
+### 3. RunPod 추천 description을 backend 설명값으로 재사용
+
+- `app/services/ai_facade.py`
+- RunPod recommendation description이 있으면
+  - `llm_explanation`
+  - `style_description`
+  fallback으로 넣는다.
+
+### 4. 회귀 테스트 추가
+
+- `app/tests/test_ai_facade.py`
+- RunPod recommendation 응답을 mock으로 주입해 다음을 검증한다.
+  - `simulation_image_url` data URL 변환
+  - `build_tag` 보존
+  - `face_shape_detected` 보존
+  - `golden_ratio_score` 보존
+  - `rag_context_excerpt` 보존
+
+## 현재 의미
+
+- backend는 이제 RunPod direct를 단순 이미지 생성 경로로만 쓰지 않는다.
+- 추천 결과의 근거 메타와 얼굴 관련 메타 일부를 recommendation snapshot에 함께 남길 수 있다.
+- 따라서 이후 고객 상세, 추천 카드, 관리자 검토 로직에서 RunPod 결과를 더 풍부하게 활용할 수 있다.
+
+## 여전히 남는 한계
+
+- 독립 얼굴 분석 전용 RunPod action은 여전히 없다.
+- 따라서 `simulate_face_analysis()` 자체는 internal/local fallback 성격을 유지한다.
+- 이번 B안은 RunPod 추천 응답 안의 얼굴 메타를 backend가 더 잘 활용하도록 만든 것이지, 독립 얼굴 분석 API를 대체한 것은 아니다.
+
+## 결론
+
+- A안은 안전한 기준선으로 유지한다.
+- B안은 RunPod direct를 실제 운영 메타까지 반영하는 방향으로 backend를 한 단계 더 direct-friendly 하게 만든다.
+- 독립 얼굴 분석까지 완전히 RunPod direct로 옮기려면, 추후 AI팀 handler에 별도 action이 추가되거나 backend가 분석 단계를 재설계해야 한다.


### PR DESCRIPTION
﻿## 개요
이번 PR은 사진 촬영 후 업로드 단계에서 발생하는 재촬영(needs_retake) 문제를 더 정확히 추적하고, backend 기준으로 먼저 가능한 캡처 기준 동기화 보강을 진행한 작업입니다.

기존에는 자동 촬영 이후 업로드가 실패해도 원인 추적이 어려웠고, `no_face_detected`, `multiple_faces_detected` 같은 실패 패턴을 구조적으로 확인하기 어려웠습니다. 이번 작업에서는 실패 로그를 구체화하고, reason 집계 및 보조 판정 로직을 추가해 backend 단독으로 가능한 범위의 안정화를 먼저 수행했습니다.

## 변경 내용
- `capture/upload` 실패 시 diagnostics 정보를 구조화해 저장하도록 보강했습니다.
- 실패 패턴 집계용 관리 명령을 추가하고 평균 진단 요약을 보강했습니다.
- `no_face_detected`, `multiple_faces_detected` 중심으로 Haar 얼굴 수 판정 보조 로직을 추가했습니다.
- 캡처 재검증 보조 판정 및 비교 로그 관련 회귀 테스트를 추가했습니다.

## 영향 범위
- `app/api/v1/django_views.py`
- `app/services/capture_validation.py`
- `app/management/commands/analyze_capture_upload_failures.py`
- `app/tests/test_designer_diagnosis_card.py`

## 검증
- `python manage.py check`
- `python manage.py analyze_capture_upload_failures --limit 200`
- 캡처 재검증 보조 판정 관련 테스트 확인

## 비고
- front가 landmark 요약값을 추가로 보내지 않는 현재 기준에서, backend가 단독으로 수행 가능한 범위까지만 반영했습니다.
- `tmp_capture_samples/` 같은 로컬 재현용 샘플은 PR 범위에서 제외합니다.
