### PR TITLE
[218] 배포 staticfiles manifest 사전 검증 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN mkdir -p storage/captures storage/processed storage/synthetic
 EXPOSE 8000
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["sh", "-c", "python manage.py collectstatic --noinput && python manage.py migrate --noinput && gunicorn --bind 0.0.0.0:8000 --pythonpath /app mirrai_project.wsgi:application"]
+CMD ["sh", "-c", "python manage.py collectstatic --noinput && python manage.py verify_static_manifest --require shared/styles/base.css && python manage.py migrate --noinput && gunicorn --bind 0.0.0.0:8000 --pythonpath /app mirrai_project.wsgi:application"]

--- a/app/management/commands/verify_static_manifest.py
+++ b/app/management/commands/verify_static_manifest.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Verify that collectstatic produced a manifest with required static entries."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--manifest-path",
+            default=None,
+            help="Optional override for the manifest file path.",
+        )
+        parser.add_argument(
+            "--require",
+            action="append",
+            default=[],
+            help="Static path that must exist in the manifest. Can be passed multiple times.",
+        )
+
+    def handle(self, *args, **options):
+        manifest_override = options["manifest_path"]
+        manifest_path = Path(manifest_override) if manifest_override else Path(settings.STATIC_ROOT) / "staticfiles.json"
+
+        if not manifest_path.exists():
+            raise CommandError(f"Staticfiles manifest not found: {manifest_path}")
+
+        try:
+            payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise CommandError(f"Staticfiles manifest is not valid JSON: {exc}") from exc
+
+        paths = payload.get("paths") or {}
+        required = options["require"] or ["shared/styles/base.css"]
+        missing = [entry for entry in required if entry not in paths]
+
+        if missing:
+            raise CommandError(
+                "Staticfiles manifest is missing required entries: " + ", ".join(sorted(missing))
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Staticfiles manifest verified: {manifest_path} ({len(required)} required entries present)"
+            )
+        )

--- a/app/tests/test_static_manifest.py
+++ b/app/tests/test_static_manifest.py
@@ -1,0 +1,37 @@
+import json
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import SimpleTestCase
+
+
+class VerifyStaticManifestCommandTests(SimpleTestCase):
+    def test_verify_static_manifest_requires_manifest_file(self):
+        with TemporaryDirectory() as tmpdir:
+            missing_path = Path(tmpdir) / "staticfiles.json"
+            with self.assertRaisesMessage(CommandError, "Staticfiles manifest not found"):
+                call_command("verify_static_manifest", manifest_path=str(missing_path))
+
+    def test_verify_static_manifest_requires_expected_entry(self):
+        with TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "staticfiles.json"
+            manifest_path.write_text(json.dumps({"paths": {"other.css": "other.123.css"}}), encoding="utf-8")
+
+            with self.assertRaisesMessage(CommandError, "shared/styles/base.css"):
+                call_command("verify_static_manifest", manifest_path=str(manifest_path))
+
+    def test_verify_static_manifest_passes_with_required_entry(self):
+        with TemporaryDirectory() as tmpdir:
+            manifest_path = Path(tmpdir) / "staticfiles.json"
+            manifest_path.write_text(
+                json.dumps({"paths": {"shared/styles/base.css": "shared/styles/base.123.css"}}),
+                encoding="utf-8",
+            )
+            stdout = StringIO()
+
+            call_command("verify_static_manifest", manifest_path=str(manifest_path), stdout=stdout)
+
+            self.assertIn("Staticfiles manifest verified", stdout.getvalue())


### PR DESCRIPTION
﻿## 개요
이번 PR은 배포 환경에서 `collectstatic` 이후 필수 static manifest entry가 정상 생성되었는지 서버 기동 전에 검증하도록 보강한 작업입니다.

기존에는 `Missing staticfiles manifest entry for 'shared/styles/base.css'` 같은 문제가 요청 시점 500으로 드러날 수 있었습니다. 이번 작업에서는 Docker 기동 전에 manifest 존재와 필수 entry를 확인하는 fail-fast 단계를 추가해, 배포 직후 뒤늦게 오류가 노출되는 상황을 줄이도록 했습니다.

## 변경 내용
- `verify_static_manifest` 관리 명령을 추가했습니다.
- `shared/styles/base.css`를 필수 검증 대상으로 지정했습니다.
- Docker 기동 순서에 `collectstatic -> verify_static_manifest -> migrate -> gunicorn` 검증 흐름을 추가했습니다.
- manifest 검증 명령 테스트를 추가했습니다.

## 영향 범위
- `Dockerfile`
- `app/management/commands/verify_static_manifest.py`
- `app/tests/test_static_manifest.py`

## 검증
- `python manage.py check`
- `python manage.py test app.tests.test_static_manifest -v 2`
- `collectstatic` 후 임시 `STATIC_ROOT` 기준 manifest entry 검증 확인

## 비고
- 이번 PR은 `settings.py` 변경 없이 backend/deploy 레벨에서만 fail-fast를 추가했습니다.
- 실제 운영 컨테이너 manifest 상태 확인은 별도 운영 확인이 필요합니다.
