### PR TITLE
feat: UI/UX 일관성 개선 및 파트너 센터 로직 최적화 (가로폭 930px 통일 및 유효성 검사 수정)

### DIFF
--- a/app/front_views.py
+++ b/app/front_views.py
@@ -641,7 +641,7 @@ def partner_verify(request):
         return JsonResponse(
             {
                 "status": "success",
-                "redirect": "/",
+                "redirect": "/partner/dashboard/",
                 "session_type": "admin",
                 "next_step": "index",
                 "shop_id": admin.id,
@@ -773,7 +773,7 @@ def enter_partner_dashboard(request):
         return JsonResponse({"status": "error", "message": "비밀번호를 다시 확인해 주세요."}, status=401)
 
     allow_owner_dashboard(request=request)
-    return JsonResponse({"status": "success", "redirect": "/partner/dashboard/"})
+    return JsonResponse({"status": "success", "redirect": "/partner/designers/"})
 
 
 @never_cache

--- a/templates/admin/customer_detail.html
+++ b/templates/admin/customer_detail.html
@@ -13,7 +13,7 @@
 {% block content %}
 <style>
   .detail-card {
-    max-width: 920px;
+    max-width: 930px;
     margin: 0 auto;
     padding: 40px 32px 32px !important;
     border-radius: 24px !important;

--- a/templates/admin/designer_select.html
+++ b/templates/admin/designer_select.html
@@ -17,10 +17,10 @@
   .content-section { margin-top: -20px !important; }
   
   #selectSection {
-    max-width: 600px; 
+    max-width: 930px; 
     min-height: 400px;
     margin: 0 auto;
-    padding: 32px !important; 
+    padding: 40px 48px !important; 
     border-radius: 24px !important;
     background: #fff;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;
@@ -39,8 +39,8 @@
   }
 
   .designer-grid {
-    display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;
-    margin-top: 24px; max-height: 300px; overflow-y: auto; padding: 4px;
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px;
+    margin-top: 24px; max-height: 400px; overflow-y: auto; padding: 4px;
   }
   .designer-card {
     padding: 14px 18px; border-radius: 16px; border: 1.5px solid var(--line);

--- a/templates/admin/designer_signup.html
+++ b/templates/admin/designer_signup.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="customer-layout" style="display: block;">
-  <div class="panel" style="max-width: 720px; margin: 0 auto; padding: 32px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
+  <div class="panel" style="max-width: 930px; margin: 0 auto; padding: 40px 48px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
     <h3 class="section-title" style="margin-bottom: 12px;">{{ active_shop.store_name|default:request.session.admin_store_name|default:request.session.admin_name|default:"MirrAI Partner" }} 디자이너 등록</h3>
     <p class="section-copy" style="margin-bottom: 24px;">이 디자이너는 현재 매장 계정에 종속되어 고객 배정과 로그인에 사용됩니다.</p>
 

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -71,7 +71,7 @@
   .tab-btn.active { color: var(--bg-dark); border-bottom-color: var(--bg-dark); }
 
   .dashboard-panel {
-    max-width: 780px;
+    max-width: 930px;
     margin: 0 auto;
     width: 100%;
   }
@@ -107,7 +107,7 @@
         <div style="display: flex; gap: 12px; align-items: center;">
           {% if not request.session.designer_id %}
             {% if not is_shop_owner %}
-              <button id="enterOwnerDashboardBtn" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; border-radius: 10px;">관리자 전용 대시보드</button>
+              <button id="enterOwnerDashboardBtn" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; border-radius: 10px;">디자이너 관리</button>
             {% else %}
               <a href="{% url 'partner_designer_management' %}" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; border-radius: 10px; display: inline-flex; align-items: center; text-decoration: none;">디자이너 관리</a>
             {% endif %}
@@ -236,7 +236,7 @@
           designers.forEach(d => {
             const opt = document.createElement('option');
             opt.value = d.name;
-            opt.textContent = `${d.name} 디자이너`;
+            opt.textContent = d.name;
             designerSelect.appendChild(opt);
           });
         }
@@ -334,24 +334,12 @@
         const sessionBadge = sessionActive
           ? '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(21, 128, 61, 0.12); color:#166534; font-size:11px; font-weight:700;">세션 진행 중</span>'
           : '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(71, 85, 105, 0.12); color:#475569; font-size:11px; font-weight:700;">세션 없음</span>';
-        const isAssignmentPending = Boolean(c.is_assignment_pending);
-        const assignmentOptions = dashboardDesigners.map(
-          designer => `<option value="${designer.id}">${designer.name}</option>`
-        ).join('');
-        const actionCell = isShopOwner && isAssignmentPending && assignmentOptions
-          ? `
-              <div style="display: flex; gap: 8px; justify-content: flex-end; align-items: center; flex-wrap: wrap;">
-                <select id="designerSelect-${c.id}" class="form-control" style="width: 132px; height: 34px; font-size: 12px; padding: 0 10px; border-radius: 8px;">
-                  <option value="">배정 선택</option>
-                  ${assignmentOptions}
-                </select>
-                <button onclick="assignCustomer(${c.id})" style="border: none; cursor: pointer; font-size: 12px; padding: 6px 12px; background: var(--accent-neon); border-radius: 20px; color: var(--bg-dark); font-weight: 700;">배정</button>
-                <button onclick="location.href='/partner/customer-detail/${c.id}/'" style="border: none; cursor: pointer; font-size: 12px; padding: 6px 14px; background: var(--bg-dark); border-radius: 20px; color: #fff; font-weight: 600;">상세보기</button>
-              </div>
-            `
-          : `
-              <button onclick="location.href='/partner/customer-detail/${c.id}/'" style="border: none; cursor: pointer; font-size: 12px; padding: 6px 14px; background: var(--bg-dark); border-radius: 20px; color: #fff; font-weight: 600;">상세보기</button>
-            `;
+        
+        // 모든 상태에서 '상세보기' 버튼만 노출하도록 통일
+        const actionCell = `
+          <button onclick="location.href='/partner/customer-detail/${c.id}/'" style="border: none; cursor: pointer; font-size: 12px; padding: 6px 14px; background: var(--bg-dark); border-radius: 20px; color: #fff; font-weight: 600;">상세보기</button>
+        `;
+
         return `
           <tr style="border-bottom: 1px solid var(--line);">
             <td style="padding: 16px 20px;"><span style="font-weight: 700; color: var(--bg-dark);">${c.name}</span></td>

--- a/templates/admin/signup.html
+++ b/templates/admin/signup.html
@@ -79,13 +79,6 @@
     justify-content: center;
   }
 
-  .info-hint {
-    font-size: 12px;
-    color: var(--text-secondary);
-    margin-top: 4px;
-    opacity: 0.8;
-  }
-
   .field-error {
     color: var(--status-red);
     font-size: 11px;
@@ -124,14 +117,6 @@
     border-radius: 16px;
     position: relative;
   }
-
-  .error-summary-list {
-    margin: 0;
-    padding-left: 18px;
-    color: var(--status-red);
-    font-size: 12px;
-    line-height: 1.6;
-  }
 </style>
 
 <div class="customer-layout" style="display: block;">
@@ -139,8 +124,7 @@
     <h3 class="section-title compact">파트너 가입 정보</h3>
 
     <div id="errorSummary" class="panel" style="display: none; background: rgba(252, 129, 129, 0.1); border: 1px solid var(--status-red); padding: 12px 16px; margin-bottom: 20px; border-radius: 12px;">
-      <p style="color: var(--status-red); font-size: 13px; font-weight: 700; margin: 0 0 8px 0;"></p>
-      <ul class="error-summary-list"></ul>
+      <p style="color: var(--status-red); font-size: 13px; font-weight: 700; margin: 0;"></p>
     </div>
 
     {% if form_error %}
@@ -154,8 +138,21 @@
 
       <div class="input-grid">
         <div class="form-field">
+          <label class="form-label">매장명 (사업자명)</label>
+          <input type="text" name="store_name" id="id_store_name" class="form-input" placeholder="사업자명 입력" required>
+          <p class="field-error" id="error_store_name"></p>
+        </div>
+        <div class="form-field">
+          <label class="form-label">사업자 등록번호</label>
+          <input type="text" name="business_number" id="id_business_number" class="form-input" placeholder="10자리 숫자" required>
+          <p class="field-error" id="error_business_number"></p>
+        </div>
+      </div>
+
+      <div class="input-grid">
+        <div class="form-field">
           <label class="form-label">대표자 성함</label>
-          <input type="text" name="name" class="form-input" placeholder="성함 입력" required>
+          <input type="text" name="name" id="id_name" class="form-input" placeholder="성함 입력" required>
           <p class="field-error" id="error_name"></p>
         </div>
         <div class="form-field">
@@ -163,56 +160,39 @@
             <span>관리자 연락처</span>
             <span style="font-size: 11px; color: var(--status-teal); font-weight: 600;">아이디로 사용됩니다.</span>
           </label>
-          <input type="tel" name="phone" class="form-input" placeholder="010-0000-0000" required>
+          <input type="tel" name="phone" id="id_phone" class="form-input" placeholder="010-1234-5678" required>
           <p class="field-error" id="error_phone"></p>
         </div>
       </div>
 
       <div class="input-grid">
         <div class="form-field">
-          <label class="form-label">매장명</label>
-          <input type="text" name="store_name" class="form-input" placeholder="매장 이름 입력" required>
-          <p class="field-error" id="error_store_name"></p>
-        </div>
-        <div class="form-field">
-          <label class="form-label">사업자 등록번호</label>
-          <input type="text" name="business_number" class="form-input" placeholder="10자리 숫자" required>
-          <p class="field-error" id="error_business_number"></p>
-        </div>
-      </div>
-
-      <div class="input-grid">
-        <div class="form-field">
           <label class="form-label">비밀번호</label>
-          <input type="password" name="password" class="form-input" placeholder="8자 이상" required>
+          <input type="password" name="password" id="id_password" class="form-input" placeholder="8자 이상" required>
           <p class="field-error" id="error_password"></p>
         </div>
         <div class="form-field">
           <label class="form-label">비밀번호 확인</label>
-          <input type="password" name="password_confirm" class="form-input" placeholder="다시 입력" required>
+          <input type="password" name="password_confirm" id="id_password_confirm" class="form-input" placeholder="다시 입력" required>
           <p class="field-error" id="error_password_confirm"></p>
         </div>
       </div>
 
-      <!-- 약관 동의 (한 줄로 정리 + 팝업 연결) -->
       <div class="agree-container" style="flex-direction: row; justify-content: flex-start; gap: 24px; padding: 12px 16px;">
         <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;" id="termsLabel">
           <input type="checkbox" name="agree_terms" id="agree_terms" required style="width: 16px; height: 16px;">
-          <span style="font-size: 13px; text-decoration: underline;">[필수] 이용약관 및 서비스 이용 동의</span>
+          <span style="font-size: 13px; text-decoration: underline;">[필수] 이용약관 동의</span>
         </label>
         <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;" id="privacyLabel">
           <input type="checkbox" name="agree_privacy" id="agree_privacy" required style="width: 16px; height: 16px;">
-          <span style="font-size: 13px; text-decoration: underline;">[필수] 개인정보 수집 및 이용 동의</span>
+          <span style="font-size: 13px; text-decoration: underline;">[필수] 개인정보 동의</span>
         </label>
         <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;" id="thirdPartyLabel">
           <input type="checkbox" name="agree_third_party_sharing" id="agree_third_party_sharing" required style="width: 16px; height: 16px;">
           <span style="font-size: 13px; text-decoration: underline;">[필수] 제3자 제공 동의</span>
         </label>
       </div>
-      <p class="field-error" id="error_agree_terms"></p>
-      <p class="field-error" id="error_agree_privacy"></p>
-      <p class="field-error" id="error_agree_third_party_sharing"></p>
-      <p class="field-error" id="error_non_field_errors"></p>
+      <p class="field-error" id="error_agreements" style="margin-left: 16px; margin-top: 0; margin-bottom: 12px;"></p>
 
       <div class="action-row">
         <button type="submit" id="submitBtn" class="btn btn-primary">가입 완료</button>
@@ -256,83 +236,19 @@
       <button class="btn btn-primary" onclick="closeModal('thirdPartyModal', 'agree_third_party_sharing')" style="width: 100%; margin-top: 24px;">확인했습니다</button>
     </div>
   </div>
-
-  <div style="max-width: 760px; margin: 24px auto 0; padding: 0 16px;">
-    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
-      <div class="panel" style="padding: 20px; border-radius: 16px; border: none; background: white;">
-        <h4 style="font-size: 14px; margin-bottom: 8px;">왜 가입해야 하나요?</h4>
-        <p style="font-size: 12px; color: var(--text-secondary); line-height: 1.6;">
-          ID 없이 전화번호와 비밀번호만으로 간편하게 로그인할 수 있습니다.
-        </p>
-      </div>
-      <div class="panel" style="padding: 20px; border-radius: 16px; border: none; background: white;">
-        <h4 style="font-size: 14px; margin-bottom: 8px;">보안 안내</h4>
-        <p style="font-size: 12px; color: var(--text-secondary); line-height: 1.6;">
-          비밀번호는 영문, 숫자, 특수문자를 조합해 안전하게 설정해주세요.
-        </p>
-      </div>
-    </div>
-  </div>
 </div>
 {% endblock %}
 
 {% block page_scripts %}
+<script src="{% static 'shared/js/validator.js' %}"></script>
 <script>
   (() => {
     const form = document.getElementById('signupForm');
     const submitBtn = document.getElementById('submitBtn');
     const errorSummary = document.getElementById('errorSummary');
     const errorSummaryTitle = errorSummary.querySelector('p');
-    const errorSummaryList = errorSummary.querySelector('.error-summary-list');
 
-    const termsLabel = document.getElementById('termsLabel');
-    const privacyLabel = document.getElementById('privacyLabel');
-    const thirdPartyLabel = document.getElementById('thirdPartyLabel');
-    const agreeTerms = document.getElementById('agree_terms');
-    const agreePrivacy = document.getElementById('agree_privacy');
-    const agreeThirdParty = document.getElementById('agree_third_party_sharing');
-    const fieldLabels = {
-      name: '대표자 성함',
-      phone: '관리자 연락처',
-      store_name: '매장명',
-      business_number: '사업자등록번호',
-      password: '비밀번호',
-      password_confirm: '비밀번호 확인',
-      agree_terms: '이용약관 동의',
-      agree_privacy: '개인정보 수집 및 이용 동의',
-      agree_third_party_sharing: '제3자 제공 동의',
-    };
-
-    function requiredFieldMessage(label) {
-      if (!label) {
-        return '필수 정보입니다.';
-      }
-      const lastChar = label[label.length - 1];
-      const code = lastChar.charCodeAt(0);
-      if (code >= 0xac00 && code <= 0xd7a3) {
-        const hasBatchim = ((code - 0xac00) % 28) !== 0;
-        return `${label}${hasBatchim ? '은' : '는'} 필수 정보입니다.`;
-      }
-      return `${label}는 필수 정보입니다.`;
-    }
-
-    function normalizeMessages(value, field = '') {
-      const rawMessages = Array.isArray(value) ? value.filter(Boolean) : (value ? [String(value)] : []);
-      return rawMessages.map((message) => {
-        const normalized = String(message || '').trim();
-        if (!normalized) {
-          return normalized;
-        }
-        if (normalized === 'This field is required.' || normalized === '필수 정보입니다.') {
-          return requiredFieldMessage(fieldLabels[field] || field || '입력 항목');
-        }
-        return normalized;
-      });
-    }
-
-    function flattenErrorMessages(errors) {
-      return Object.entries(errors || {}).flatMap(([field, value]) => normalizeMessages(value, field));
-    }
+    const validator = window.MirrAIValidator;
 
     function openModal(id) {
       const modal = document.getElementById(id);
@@ -345,93 +261,116 @@
       if (checkboxId) {
         const checkbox = document.getElementById(checkboxId);
         if (checkbox) checkbox.checked = true;
+        clearErrors();
       }
     }
 
     function clearErrors() {
       document.querySelectorAll('.field-error').forEach((el) => {
         el.textContent = '';
+        el.style.display = 'none';
       });
-      errorSummaryTitle.textContent = '';
-      errorSummaryList.innerHTML = '';
-      errorSummary.style.display = 'none';
+      document.querySelectorAll('.form-input').forEach((el) => {
+        el.classList.remove('is-invalid');
+      });
+      if (errorSummary) errorSummary.style.display = 'none';
     }
 
-    function showFieldError(field, messages) {
+    function showFieldError(field, message) {
       const target = document.getElementById(`error_${field}`);
-      if (!target) return;
-      const normalized = normalizeMessages(messages, field);
-      target.textContent = normalized.join(' ');
-    }
-
-    function showSummary(title, messages) {
-      errorSummaryTitle.textContent = title;
-      errorSummaryList.innerHTML = '';
-      messages.forEach((message) => {
-        const li = document.createElement('li');
-        li.textContent = message;
-        errorSummaryList.appendChild(li);
-      });
-      errorSummary.style.display = 'block';
-    }
-
-    function handleAgreementToggle(event, modalId, checkboxId) {
-      event.preventDefault();
-      event.stopPropagation();
-      const checkbox = checkboxId ? document.getElementById(checkboxId) : null;
-      if (checkbox && checkbox.checked) {
-        checkbox.checked = false;
-        return;
+      const input = document.getElementById(`id_${field}`);
+      if (target) {
+        target.textContent = message;
+        target.style.display = 'block';
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }
-      openModal(modalId);
+      if (input) {
+        input.classList.add('is-invalid');
+        input.focus();
+      }
     }
 
-    function bindAgreementTrigger(trigger, modalId, checkboxId) {
-      if (!trigger) return;
-      const eventName = trigger.tagName === 'INPUT' ? 'pointerdown' : 'click';
-      trigger.addEventListener(eventName, (event) => {
-        if (trigger.tagName === 'LABEL' && event.target && event.target.id === checkboxId) {
-          return;
+    function validateForm() {
+      clearErrors();
+
+      const storeName = form.querySelector('input[name="store_name"]').value.trim();
+      const businessNumber = form.querySelector('input[name="business_number"]').value.replace(/[^0-9]/g, '');
+      const name = form.querySelector('input[name="name"]').value.trim();
+      const phone = form.querySelector('input[name="phone"]').value.trim();
+      const password = form.querySelector('input[name="password"]').value;
+      const confirm = form.querySelector('input[name="password_confirm"]').value;
+
+      // 1. 매장명 (사업자명)
+      if (!storeName) {
+        showFieldError('store_name', '매장명(사업자명)을 입력해 주세요.');
+        return false;
+      }
+
+      // 2. 사업자 등록번호
+      if (businessNumber.length !== 10) {
+        showFieldError('business_number', '사업자 등록번호 10자리를 정확히 입력해 주세요.');
+        return false;
+      }
+
+      // 3. 대표자 성함
+      if (!validator || !validator.isValidName(name)) {
+        showFieldError('name', '대표자 성함을 2~10자 이내로 입력해 주세요.');
+        return false;
+      }
+
+      // 4. 관리자 연락처
+      if (!validator || !validator.isValidPhone(phone)) {
+        showFieldError('phone', '연락처 형식이 올바르지 않습니다. (예: 010-1234-5678)');
+        return false;
+      }
+
+      // 5. 비밀번호
+      if (!password || password.length < 8) {
+        showFieldError('password', '비밀번호를 8자 이상 입력해 주세요.');
+        return false;
+      }
+
+      // 6. 비밀번호 확인
+      if (password !== confirm) {
+        showFieldError('password_confirm', '비밀번호가 일치하지 않습니다.');
+        return false;
+      }
+
+      // 7. 약관 동의
+      if (!document.getElementById('agree_terms').checked || 
+          !document.getElementById('agree_privacy').checked || 
+          !document.getElementById('agree_third_party_sharing').checked) {
+        showFieldError('agreements', '모든 필수 약관에 동의해 주세요.');
+        return false;
+      }
+
+      return true;
+    }
+
+    // 약관 이벤트 바인딩
+    ['terms', 'privacy', 'thirdParty'].forEach(key => {
+      const label = document.getElementById(`${key}Label`);
+      const checkbox = document.getElementById(`agree_${key === 'thirdParty' ? 'third_party_sharing' : key}`);
+      
+      label.addEventListener('click', (e) => {
+        if (e.target !== checkbox) {
+          e.preventDefault();
+          openModal(`${key}Modal`);
         }
-        handleAgreementToggle(event, modalId, checkboxId);
       });
-    }
+    });
 
-    window.openModal = openModal;
     window.closeModal = closeModal;
 
-    bindAgreementTrigger(termsLabel, 'termsModal', 'agree_terms');
-    bindAgreementTrigger(privacyLabel, 'privacyModal', 'agree_privacy');
-    bindAgreementTrigger(thirdPartyLabel, 'thirdPartyModal', 'agree_third_party_sharing');
-    bindAgreementTrigger(agreeTerms, 'termsModal', 'agree_terms');
-    bindAgreementTrigger(agreePrivacy, 'privacyModal', 'agree_privacy');
-    bindAgreementTrigger(agreeThirdParty, 'thirdPartyModal', 'agree_third_party_sharing');
-
-    window.addEventListener('click', (event) => {
-      if (event.target.classList.contains('modal')) {
-        event.target.classList.remove('show');
-      }
+    // 실시간 포맷팅
+    form.querySelector('input[name="phone"]').addEventListener('input', (e) => {
+      if (validator) e.target.value = validator.formatPhone(e.target.value);
     });
 
     form.addEventListener('submit', async (event) => {
       event.preventDefault();
-      clearErrors();
-
-      const businessNumber = form.querySelector('input[name="business_number"]').value.replace(/[^0-9]/g, '');
-      const password = form.querySelector('input[name="password"]').value;
-      const confirm = form.querySelector('input[name="password_confirm"]').value;
-
-      if (businessNumber.length !== 10) {
-        showFieldError('business_number', '사업자 등록번호 10자리를 정확히 입력해 주세요.');
-        showSummary('입력한 정보를 다시 확인해 주세요.', ['사업자 등록번호 10자리를 정확히 입력해 주세요.']);
-        return;
-      }
-
-      if (password !== confirm) {
-        showFieldError('password_confirm', '비밀번호가 일치하지 않습니다.');
-        showSummary('입력한 정보를 다시 확인해 주세요.', ['비밀번호가 일치하지 않습니다.']);
-        return;
-      }
+      
+      if (!validateForm()) return;
 
       submitBtn.disabled = true;
       submitBtn.textContent = '처리 중...';
@@ -439,20 +378,14 @@
       try {
         const formData = new FormData(form);
         const payload = {};
-
         formData.forEach((value, key) => {
           if (key === 'business_number') {
-            payload[key] = businessNumber;
-            return;
-          }
-          if (key === 'password_confirm') {
-            return;
-          }
-          if (key.startsWith('agree_')) {
+            payload[key] = value.replace(/[^0-9]/g, '');
+          } else if (key.startsWith('agree_')) {
             payload[key] = true;
-            return;
+          } else if (key !== 'password_confirm') {
+            payload[key] = value;
           }
-          payload[key] = value;
         });
 
         const response = await fetch(form.dataset.apiAction, {
@@ -471,20 +404,18 @@
           return;
         }
 
-        const errorMessages = flattenErrorMessages(data.errors || {});
-        if (data.errors && typeof data.errors === 'object') {
-          Object.entries(data.errors).forEach(([field, messages]) => {
-            showFieldError(field, messages);
-          });
+        // 서버 에러 처리 (API에서 온 에러)
+        if (data.errors) {
+          const firstField = Object.keys(data.errors)[0];
+          showFieldError(firstField, Array.isArray(data.errors[firstField]) ? data.errors[firstField][0] : data.errors[firstField]);
+        } else {
+          errorSummaryTitle.textContent = data.message || '회원가입에 실패했습니다.';
+          errorSummary.style.display = 'block';
         }
-
-        showSummary(
-          data.message || '입력한 정보를 다시 확인해 주세요.',
-          errorMessages.length ? errorMessages : [data.message || '회원가입에 실패했습니다.']
-        );
       } catch (error) {
         console.error('Signup Error:', error);
-        showSummary('회원가입 요청 처리 중 오류가 발생했습니다.', ['잠시 후 다시 시도해 주세요.']);
+        errorSummaryTitle.textContent = '통신 중 오류가 발생했습니다.';
+        errorSummary.style.display = 'block';
       } finally {
         submitBtn.disabled = false;
         submitBtn.textContent = '가입 완료';

--- a/templates/customer/consultation_complete.html
+++ b/templates/customer/consultation_complete.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 <div class="customer-layout" style="display: block;">
-  <div class="panel" style="max-width: 760px; margin: 0 auto; padding: 32px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
+  <div class="panel" style="max-width: 930px; margin: 0 auto; padding: 40px 48px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
     <h3 class="section-title" style="margin-bottom: 16px;">{{ client.name }}님의 상담 요청이 접수되었습니다.</h3>
     <p class="section-copy" style="margin-bottom: 24px;">10초 동안 아무 동작이 없으면 자동으로 로그아웃된 뒤 메인 페이지로 이동합니다.</p>
 

--- a/templates/customer/index.html
+++ b/templates/customer/index.html
@@ -13,9 +13,9 @@
 {% block content %}
 <style>
   .customer-input-card {
-    max-width: 600px;
+    max-width: 930px;
     margin: 0 auto;
-    padding: 32px !important;
+    padding: 40px 48px !important;
     border-radius: 24px !important;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;
   }
@@ -113,6 +113,20 @@
     border: 1.5px solid var(--line) !important;
   }
 
+  /* 필드별 에러 스타일 추가 */
+  .field-error {
+    color: #ff3b30;
+    font-size: 11px;
+    margin-top: 4px;
+    font-weight: 600;
+    display: none;
+  }
+
+  .form-input.is-invalid {
+    border-color: #ff3b30 !important;
+    background-color: rgba(255, 59, 48, 0.02);
+  }
+
   .agree-box {
     margin-top: 8px;
     padding: 12px 16px;
@@ -141,6 +155,12 @@
 <div class="customer-layout" style="display: block;">
 <div class="panel customer-input-card">
     <h3 class="section-title compact">고객 정보 입력</h3>
+    
+    <div id="errorSummary" class="panel" style="display: none; background: rgba(252, 129, 129, 0.1); border: 1px solid #ff3b30; padding: 12px 16px; margin-bottom: 20px; border-radius: 12px;">
+      <p style="color: #ff3b30; font-size: 13px; font-weight: 700; margin: 0 0 4px 0;">입력한 정보를 다시 확인해 주세요.</p>
+      <ul id="errorList" style="margin: 0; padding-left: 18px; color: #ff3b30; font-size: 12px; line-height: 1.6;"></ul>
+    </div>
+
     {% if form_error %}
       <p style="margin-bottom: 16px; color: #ff3b30; font-size: 14px; font-weight: 700;">{{ form_error }}</p>
     {% endif %}
@@ -152,6 +172,7 @@
         <div class="form-field">
           <label class="form-label">성함</label>
           <input type="text" name="name" id="id_name" class="form-input" placeholder="성함 입력" tabindex="1" required>
+          <p class="field-error" id="error_name"></p>
         </div>
 
         <div class="form-field">
@@ -166,6 +187,7 @@
               <span>여성</span>
             </label>
           </div>
+          <p class="field-error" id="error_gender"></p>
         </div>
       </div>
 
@@ -173,10 +195,12 @@
         <div class="form-field">
           <label class="form-label">연령</label>
           <input type="text" name="age" id="id_age" class="form-input" placeholder="나이(숫자)" inputmode="numeric" pattern="[0-9]*" tabindex="4" required>
+          <p class="field-error" id="error_age"></p>
         </div>
         <div class="form-field">
           <label class="form-label">연락처</label>
           <input type="tel" name="phone" id="id_phone" class="form-input" placeholder="010-0000-0000" tabindex="5" required>
+          <p class="field-error" id="error_phone"></p>
         </div>
       </div>
 
@@ -187,6 +211,7 @@
             <b>[필수]</b> AI 스타일 분석을 위한 데이터 수집 동의
           </span>
         </label>
+        <p class="field-error" id="error_privacy" style="margin-top: 8px;"></p>
       </div>
 
       <div class="action-row">
@@ -229,6 +254,9 @@
     const confirmTerms = document.getElementById('confirmTerms');
     const genderBtns = document.querySelectorAll('.gender-btn');
 
+    // 공통 모듈 연결
+    const validator = window.MirrAIValidator;
+
     const toggleAgreement = (e) => {
       if (e) {
         e.preventDefault();
@@ -250,6 +278,10 @@
       }
       if (parsed < 0) {
         ageInput.value = '0';
+        return;
+      }
+      if (parsed > 120) {
+        ageInput.value = '120';
         return;
       }
       ageInput.value = String(Math.floor(parsed));
@@ -282,6 +314,7 @@
 
     confirmTerms.addEventListener('click', () => {
       privacyAgree.checked = true;
+      clearErrors();
       termsModal.classList.remove('show');
     });
 
@@ -289,24 +322,101 @@
       if (e.target === termsModal) termsModal.classList.remove('show');
     });
 
+    const mainBtn = document.querySelector('a.btn-outline');
+    if (mainBtn) {
+      mainBtn.addEventListener('click', clearErrors);
+    }
+
+    function clearErrors() {
+      // 상단 요약박스 숨김
+      const errorSummary = document.getElementById('errorSummary');
+      if (errorSummary) errorSummary.style.display = 'none';
+      
+      // 개별 필드 에러 초기화
+      document.querySelectorAll('.field-error').forEach(el => {
+        el.textContent = '';
+        el.style.display = 'none';
+      });
+      document.querySelectorAll('.form-input').forEach(el => {
+        el.classList.remove('is-invalid');
+      });
+    }
+
+    function showFieldError(fieldId, message) {
+      const errorEl = document.getElementById(`error_${fieldId}`);
+      const inputEl = document.getElementById(`id_${fieldId}`);
+      
+      if (errorEl) {
+        errorEl.textContent = message;
+        errorEl.style.display = 'block';
+      }
+      if (inputEl) {
+        inputEl.classList.add('is-invalid');
+        inputEl.focus();
+      }
+      
+      // 스크롤 처리
+      const scrollTarget = errorEl || inputEl;
+      if (scrollTarget) {
+        scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+
     function validateForm() {
-      if (!validator.validateName(nameInput.value)) { alert('이름을 입력해 주세요.'); nameInput.focus(); return false; }
+      clearErrors();
+
+      // 1. 성함 (순서 보장 및 즉시 리턴으로 1개씩만 표시)
+      if (!validator || !validator.isValidName(nameInput.value)) { 
+        showFieldError('name', '성함을 2~10자 이내로 정확히 입력해 주세요.'); 
+        return false;
+      }
+      
+      // 2. 성별
       const gender = form.querySelector('input[name="gender"]:checked');
-      if (!gender) { alert('성별을 선택해 주세요.'); return false; }
-      if (!validator.validateAge(ageInput.value)) { alert('연령을 정확히 입력해 주세요.'); ageInput.focus(); return false; }
-      if (!validator.validatePhone(phoneInput.value)) { alert('연락처를 정확히 입력해 주세요.'); phoneInput.focus(); return false; }
-      if (!privacyAgree.checked) { alert('서비스 이용을 위해 데이터 수집에 동의해 주세요.'); privacyAgree.focus(); return false; }
+      if (!gender) { 
+        showFieldError('gender', '성별을 선택해 주세요.'); 
+        return false;
+      }
+      
+      // 3. 연령
+      const ageVal = ageInput.value.trim();
+      if (!ageVal || isNaN(ageVal) || parseInt(ageVal) <= 0) { 
+        showFieldError('age', '연령을 숫자 형식으로 정확히 입력해 주세요.'); 
+        return false;
+      }
+      
+      // 4. 연락처
+      if (!validator || !validator.isValidPhone(phoneInput.value)) { 
+        showFieldError('phone', '연락처 형식이 올바르지 않습니다. (예: 010-1234-5678)'); 
+        return false;
+      }
+
+      // 5. 동의
+      if (!privacyAgree.checked) { 
+        showFieldError('privacy', '서비스 이용을 위해 데이터 수집에 동의해 주세요.'); 
+        return false;
+      }
+
       return true;
     }
 
     phoneInput.addEventListener('input', (e) => {
-      phoneInput.value = validator.formatPhone(e.target.value);
+      if (validator) {
+        phoneInput.value = validator.formatPhone(e.target.value);
+      }
     });
     ageInput.addEventListener('input', clampAgeValue);
     ageInput.addEventListener('change', clampAgeValue);
 
     form.addEventListener('submit', (e) => {
-      if (!validateForm()) e.preventDefault();
+      // 기본 제출 기능을 즉시 차단하여 페이지 새로고침(데이터 유실)을 방지합니다.
+      e.preventDefault();
+
+      // 유효성 검사를 수행합니다.
+      if (validateForm()) {
+        // 모든 검증이 통과된 경우에만 폼을 서버로 전송합니다.
+        form.submit();
+      }
     });
 
     syncGenderButtons();

--- a/templates/customer/survey.html
+++ b/templates/customer/survey.html
@@ -7,11 +7,11 @@
 <style>
   /* 컴팩트하고 세련된 설문 카드 스타일 */
   .customer-input-card.survey-mode {
-    max-width: 600px;
+    max-width: 930px;
     margin: 0 auto;
-    padding: 20px !important;
+    padding: 40px 48px !important;
     border-radius: 20px !important;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05) !important;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;
     background: white;
     border: 1px solid #f0f0f0 !important;
   }


### PR DESCRIPTION
# 작업 보고서 (2026-04-06)

## 1. 개요
오늘 작업은 프론트엔드 유효성 검사 오류 해결, 사용자 경험(UX) 개선을 위한 폼 레이아웃 조정, 그리고 전체적인 서비스 레이아웃 규격(930px) 통일에 중점을 두었습니다.

## 2. 주요 작업 내용
### 2.1 JavaScript 유효성 검사 및 오류 수정
- **문제**: `customer/index.html`에서 전역 `validator` 객체 미정의 및 메서드 명칭 불일치로 인해 폼 제출이 중단되는 현상 발생.
- **해결**:
  - `window.MirrAIValidator`를 `validator` 변수로 연결.
  - 공통 모듈 규격에 맞춰 `validateName` → `isValidName`, `validatePhone` → `isValidPhone`으로 호출부 수정.
  - Utility에 없는 `isValidAge` 로직을 인라인으로 보완.

### 2.2 입력 폼 UX 개선 (고객 페이지 및 파트너 가입)
- **순차 검증**: 에러를 한꺼번에 띄우지 않고 성함 > 성별 > 연령 순으로 하나씩 검증하여 흐름 제어.
- **필드별 에러**: 에러 발생 시 입력창 바로 아래에 1줄의 메시지를 노출하고, 해당 필드로 자동 스크롤 및 포커스 이동.
- **파트너 가입 폼**: 요청 이미지에 맞춰 항목 배치(매장명/사업자번호 우선) 및 순서(Z-pattern) 재정리.

### 2.3 레이아웃 규격 통일 (930px)
- **기준**: `customer_detail.html`의 920px + 10px 여유분을 더한 **930px**을 공통 규격으로 설정.
- **적용 페이지**:
  - 고객 로그인 및 정보 입력 (`/customer/`)
  - 스타일 취향 설문 (`/customer/survey/`)
  - 상담 완료 안내 (`/customer/consultation/complete/`)
  - 디자이너 선택 및 PIN 인증 (`/partner/designer-select/`) - 3열 그리드로 확장
  - 신규 디자이너 등록 (`/partner/designers/new/`)
  - 파트너/디자이너 대시보드 (`/partner/dashboard/`, `/partner/staff/`)

### 2.4 파트너 센터 비즈니스 로직 최적화
- **리다이렉트 개선**: 매장 관리자 로그인 시 서비스 메인(`/`)이 아닌 대시보드(`/partner/dashboard/`)로 즉시 연결되도록 백엔드 수정.
- **권한 연동**: 대시보드의 '디자이너 관리' 버튼 클릭 시 비밀번호 재인증 후 디자이너 리스트 관리 페이지(`/partner/designers/`)로 리다이렉트되도록 변경.
- **리스트 단일화**: 대시보드 고객 목록에서 디자이너 배정 여부와 관계없이 '상세보기' 중심의 단일화된 템플릿 사용.

## 3. 향후 참고 사항
- 모든 페이지의 가로 규격이 930px로 통일되었으므로, 향후 추가되는 신규 페이지도 `.detail-card` 또는 `.dashboard-panel` 규격을 따를 것을 권장합니다.
- `validator.js`는 `isValid...` 형태의 Boolean 반환 유틸리티로 계속 유지하며, 메시지 처리는 페이지별로 관리하는 현재의 구조가 유지보수에 유리합니다.