### PR TITLE
fix: 매장 로그인 상태에서 메인 이동 시 세션 유지 및 헤더 메인 링크 추가

### DIFF
--- a/app/front_views.py
+++ b/app/front_views.py
@@ -30,7 +30,6 @@ from app.session_state import (
     allow_owner_dashboard,
     can_access_owner_dashboard,
     clear_admin_session,
-    clear_all_sessions,
     clear_customer_session,
     clear_designer_session,
     get_session_admin,
@@ -164,7 +163,6 @@ def health_check(request):
 
 
 def home_page(request):
-    clear_all_sessions(request=request)
     return render(request, "index.html", {"start_url": "/customer/", "partner_url": "/partner/login/"})
 
 

--- a/templates/layouts/base_site.html
+++ b/templates/layouts/base_site.html
@@ -21,6 +21,7 @@
           </a>
 
           <nav class="nav-links">
+            <a href="{% url 'index' %}" class="nav-link">메인</a>
             {% if not request.session.admin_id %}
               <a href="{% url 'partner_index' %}?next=/partner/designer-select/?next=/customer/" class="nav-link">분석 시작하기</a>
             {% elif not request.session.designer_id %}


### PR DESCRIPTION
## 내용
### 변경 배경
- 매장 로그인 상태에서 헤더 로고를 클릭하면 `home_page()`에서 세션을 `flush()` 하면서 로그아웃되었습니다.
- 이 과정에서 `SessionInterrupted` 예외가 발생할 수 있었습니다.

### 변경 사항
- `app/front_views.py`
  - `home_page()`에서 `clear_all_sessions()` 호출 제거
  - 메인 페이지 이동 시 세션이 유지되도록 수정
- `templates/layouts/base_site.html`
  - 헤더 내비게이션에 `메인` 링크 추가
  - 로고 클릭과 `메인` 링크 모두 공개 메인으로 이동하되 세션은 유지되도록 정리

### 기대 효과
- 매장 관리자, 디자이너, 고객 로그인 상태에서 로고 클릭 시 로그아웃되지 않음
- 메인 페이지 이동과 로그아웃 동작이 명확히 분리됨
- `SessionInterrupted` 발생 가능성 완화

### 확인 사항
- 매장 로그인 후 로고 클릭 시 세션 유지
- 매장 로그인 후 `메인` 클릭 시 세션 유지
- 기존 로그아웃 버튼은 정상적으로 세션 종료
- `python -m py_compile app/front_views.py` 통과