### PR TITLE
feat: 최신 트렌드 API 및 RunPod 핸들러 추가, 데이터 구조 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,51 @@ curl "http://localhost:8000/api/v1/analysis/trend/latest/?limit=5"
 - `refresh_trends` / `run_trend_scheduler` = 전체 크롤링 + 정제 + 후처리
 - `/api/v1/analysis/trend/latest/` = 저장된 데이터에서 최신 5개만 조회
 
+#### RunPod 최신 피드 우선 조회(선택)
+
+최신 트렌드 API는 아래 환경 변수가 켜져 있으면
+`RunPod -> 로컬 ChromaDB -> 로컬 JSON` 순서로 조회를 시도합니다.
+
+```env
+TREND_LATEST_REMOTE_ENABLED=true
+TREND_LATEST_RUNPOD_TIMEOUT=8
+TREND_LATEST_RUNPOD_POLL_INTERVAL=2
+```
+
+RunPod 핸들러는 아래 입력을 받아야 합니다.
+
+```json
+{
+  "input": {
+    "action": "latest_trends",
+    "limit": 5
+  }
+}
+```
+
+권장 응답 형태:
+
+```json
+{
+  "status": "ready",
+  "items": [
+    {
+      "title": "Golden-Hour Brunette",
+      "title_ko": "골든아워 브루넷",
+      "summary": "Warm brunette trend...",
+      "summary_ko": "따뜻한 브루넷 컬러 트렌드...",
+      "image_url": "https://...",
+      "article_url": "https://...",
+      "source": "Whowhatwear",
+      "published_at": "2026-03-29T08:00:00+00:00",
+      "crawled_at": "2026-04-07T00:46:17+00:00",
+      "category": "color_trend",
+      "keywords": ["브루넷", "브라운"]
+    }
+  ]
+}
+```
+
 ---
 
 ## 🔗 주요 접속 경로 (Local Access Paths)

--- a/app/trend_pipeline/latest_feed.py
+++ b/app/trend_pipeline/latest_feed.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from .paths import TREND_PROCESSED_DIR, TREND_RAW_DIR
+from .paths import CHROMA_TRENDS_DIR, TREND_PROCESSED_DIR, TREND_RAW_DIR
 
 try:
     from django.conf import settings as django_settings
@@ -19,6 +19,9 @@ except Exception:  # pragma: no cover - standalone script path
 REFINED_TRENDS_FILE = TREND_PROCESSED_DIR / "refined_trends.json"
 TRANSLATION_CACHE_FILE = TREND_PROCESSED_DIR / "latest_trend_translations.json"
 DEFAULT_TRANSLATION_MODEL = "gemini-2.5-flash"
+CHROMA_COLLECTION_NAME = "hair_trends"
+DEFAULT_RUNPOD_LATEST_TIMEOUT = 8
+DEFAULT_RUNPOD_LATEST_POLL_INTERVAL = 2.0
 
 STYLE_INCLUDE_KEYWORDS = (
     "hairstyle",
@@ -252,6 +255,161 @@ def _iter_raw_items() -> list[dict[str, Any]]:
     for path in sorted(TREND_RAW_DIR.glob("*.json")):
         items.extend(_load_json_list(path))
     return items
+
+
+def _iter_chroma_items() -> list[dict[str, Any]]:
+    if not CHROMA_TRENDS_DIR.exists():
+        return []
+
+    try:
+        import chromadb
+    except Exception:
+        return []
+
+    try:
+        client = chromadb.PersistentClient(path=str(CHROMA_TRENDS_DIR))
+        collection = client.get_collection(CHROMA_COLLECTION_NAME)
+        payload = collection.get(include=["metadatas"])
+    except Exception:
+        return []
+
+    metadatas = payload.get("metadatas") if isinstance(payload, dict) else None
+    if not isinstance(metadatas, list):
+        return []
+
+    items: list[dict[str, Any]] = []
+    has_feed_metadata = False
+    for metadata in metadatas:
+        if not isinstance(metadata, dict):
+            continue
+        row = dict(metadata)
+        if row.get("article_url") or row.get("image_url") or row.get("published_at") or row.get("crawled_at"):
+            has_feed_metadata = True
+        items.append(row)
+
+    return items if has_feed_metadata else []
+
+
+def _is_enabled(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _runpod_latest_enabled() -> bool:
+    return _is_enabled(
+        os.environ.get("TREND_LATEST_REMOTE_ENABLED")
+        or _get_django_setting("TREND_LATEST_REMOTE_ENABLED", "")
+    )
+
+
+def _runpod_latest_timeout() -> int:
+    raw = os.environ.get("TREND_LATEST_RUNPOD_TIMEOUT") or _get_django_setting("TREND_LATEST_RUNPOD_TIMEOUT", "")
+    try:
+        return max(3, int(str(raw).strip()))
+    except (TypeError, ValueError):
+        return DEFAULT_RUNPOD_LATEST_TIMEOUT
+
+
+def _runpod_latest_poll_interval() -> float:
+    raw = os.environ.get("TREND_LATEST_RUNPOD_POLL_INTERVAL") or _get_django_setting("TREND_LATEST_RUNPOD_POLL_INTERVAL", "")
+    try:
+        return max(0.5, float(str(raw).strip()))
+    except (TypeError, ValueError):
+        return DEFAULT_RUNPOD_LATEST_POLL_INTERVAL
+
+
+def _normalize_remote_item(item: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+
+    title = str(item.get("title") or item.get("display_title") or item.get("article_title") or "").strip()
+    if not title:
+        return None
+
+    return {
+        "title": title,
+        "summary": _compact_summary(item.get("summary") or item.get("description") or ""),
+        "image_url": str(item.get("image_url") or "").strip() or None,
+        "article_url": str(item.get("article_url") or "").strip() or None,
+        "source": str(item.get("source") or "").strip() or "Unknown",
+        "published_at": str(item.get("published_at") or "").strip() or None,
+        "crawled_at": str(item.get("crawled_at") or "").strip() or None,
+        "category": str(item.get("category") or "").strip() or "trend",
+        "keywords": item.get("keywords") if isinstance(item.get("keywords"), list) else [],
+        "title_ko": str(item.get("title_ko") or "").strip(),
+        "summary_ko": str(item.get("summary_ko") or "").strip(),
+    }
+
+
+def _localize_items_preserving_existing(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    to_translate = [
+        {"title": item.get("title", ""), "summary": item.get("summary", ""), "article_url": item.get("article_url", "")}
+        for item in items
+        if not item.get("title_ko") or not item.get("summary_ko")
+    ]
+    translated_lookup: dict[str, dict[str, Any]] = {}
+    if to_translate:
+        translated_items = _attach_korean_fields(to_translate)
+        translated_lookup = {
+            _translation_cache_key(item): item
+            for item in translated_items
+        }
+
+    localized: list[dict[str, Any]] = []
+    for item in items:
+        key = _translation_cache_key(item)
+        translated = translated_lookup.get(key, {})
+        localized.append(
+            {
+                **item,
+                "title_ko": item.get("title_ko") or translated.get("title_ko") or item.get("title", ""),
+                "summary_ko": item.get("summary_ko") or translated.get("summary_ko") or item.get("summary", ""),
+            }
+        )
+    return localized
+
+
+def _load_runpod_latest_trends(*, limit: int) -> dict[str, Any] | None:
+    if not _runpod_latest_enabled():
+        return None
+
+    try:
+        from app.services.trend_refresh import _submit_runpod_job
+    except Exception:
+        return None
+
+    try:
+        payload = _submit_runpod_job(
+            request_input={"action": "latest_trends", "limit": max(1, min(int(limit), 5))},
+            endpoint_id=None,
+            api_key=None,
+            base_url=None,
+            sync=True,
+            wait=True,
+            timeout=_runpod_latest_timeout(),
+            poll_interval=_runpod_latest_poll_interval(),
+        )
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    items = payload.get("items")
+    if not isinstance(items, list):
+        data = payload.get("data")
+        if isinstance(data, dict):
+            items = data.get("items")
+    if not isinstance(items, list):
+        return None
+
+    normalized_items = [normalized for row in items if (normalized := _normalize_remote_item(row)) is not None]
+    localized_items = _localize_items_preserving_existing(normalized_items)
+    return {
+        "status": "ready",
+        "source": "runpod_latest_trends",
+        "count": len(localized_items),
+        "items": localized_items[: max(1, min(int(limit), 5))],
+    }
 
 
 def _parse_datetime(value: Any) -> datetime | None:
@@ -566,7 +724,18 @@ def _attach_korean_fields(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def get_latest_crawled_trends(*, limit: int = 5) -> dict[str, Any]:
-    raw_items = _load_json_list(REFINED_TRENDS_FILE) or _iter_raw_items()
+    remote_payload = _load_runpod_latest_trends(limit=limit)
+    if remote_payload is not None:
+        return remote_payload
+
+    source_label = "chromadb_trends"
+    raw_items = _iter_chroma_items()
+    if not raw_items:
+        source_label = "refined_trends_json"
+        raw_items = _load_json_list(REFINED_TRENDS_FILE)
+    if not raw_items:
+        source_label = "raw_trends_json"
+        raw_items = _iter_raw_items()
 
     normalized_items: list[dict[str, Any]] = []
     seen_keys: set[str] = set()
@@ -604,7 +773,7 @@ def get_latest_crawled_trends(*, limit: int = 5) -> dict[str, Any]:
 
     return {
         "status": "ready",
-        "source": "latest_crawled_trends",
+        "source": source_label,
         "count": len(localized_items),
         "items": localized_items,
     }

--- a/app/trend_pipeline/llm_refiner.py
+++ b/app/trend_pipeline/llm_refiner.py
@@ -125,6 +125,11 @@ class LLMRefiner:
                             "search_text": result.get("search_text", ""),
                             "source": item.get("source", "Unknown"),
                             "year": str(item.get("year", "")),
+                            "article_title": item.get("article_title", ""),
+                            "article_url": item.get("article_url", ""),
+                            "image_url": item.get("image_url", ""),
+                            "published_at": item.get("published_at", ""),
+                            "crawled_at": item.get("crawled_at", ""),
                         }
                     )
                     print(f"   ✓ [채택] 카테고리: {result.get('category')} | 정규화: {result.get('canonical_name', '')}")

--- a/app/trend_pipeline/vectorize_chromadb.py
+++ b/app/trend_pipeline/vectorize_chromadb.py
@@ -39,6 +39,11 @@ def _normalize_refined_item(item: dict) -> dict:
     description = str(item.get("description", "")).strip()
     style_tags = _split_csv(item.get("hairstyle_text", ""))
     color_tags = _split_csv(item.get("color_text", ""))
+    article_title = str(item.get("article_title", "")).strip()
+    article_url = str(item.get("article_url", "")).strip()
+    image_url = str(item.get("image_url", "")).strip()
+    published_at = str(item.get("published_at", "")).strip()
+    crawled_at = str(item.get("crawled_at", "")).strip()
 
     category = "style_trend"
     if color_tags and not style_tags:
@@ -64,6 +69,11 @@ def _normalize_refined_item(item: dict) -> dict:
         "search_text": "\n".join(chunk for chunk in search_chunks if chunk),
         "source": item.get("source", ""),
         "year": str(item.get("year", "")),
+        "article_title": article_title,
+        "article_url": article_url,
+        "image_url": image_url,
+        "published_at": published_at,
+        "crawled_at": crawled_at,
     }
 
 
@@ -125,6 +135,11 @@ def build_collection() -> chromadb.api.models.Collection.Collection:
                     "summary": item.get("summary", ""),
                     "source": item.get("source", ""),
                     "year": item.get("year", ""),
+                    "article_title": item.get("article_title", ""),
+                    "article_url": item.get("article_url", ""),
+                    "image_url": item.get("image_url", ""),
+                    "published_at": item.get("published_at", ""),
+                    "crawled_at": item.get("crawled_at", ""),
                 }
             )
 


### PR DESCRIPTION
## 제목
feat: 최신 트렌드 피드에 RunPod/Chroma 우선 조회 구조 추가

## 변경 내용
- 최신 트렌드 피드 로직을 `RunPod -> 로컬 ChromaDB -> 로컬 JSON` fallback 구조로 확장
- `TREND_LATEST_REMOTE_ENABLED`, `TREND_LATEST_RUNPOD_TIMEOUT`, `TREND_LATEST_RUNPOD_POLL_INTERVAL` 환경 변수 추가
- `vectorize_chromadb.py`에서 Chroma 메타데이터에 `article_title`, `article_url`, `image_url`, `published_at`, `crawled_at` 저장하도록 보강
- `llm_refiner.py`에서 정제 결과에 기사 메타데이터를 유지하도록 보강
- `latest_feed.py`에서 Chroma 메타데이터 기반 최신 5개 조회 로직 추가
- RunPod `latest_trends` 액션 응답을 받을 수 있도록 원격 우선 조회 분기 추가
- RunPod 실패 또는 미구현 시 기존 로컬 JSON fallback 유지
- README에 `전체 갱신`과 `최신 5개 조회` 차이, RunPod 최신 피드 연동 방식, 요청/응답 스펙 문서화
- `.env`에 RunPod 최신 피드 관련 설정 추가

## 수정 파일
- `app/trend_pipeline/vectorize_chromadb.py`
- `app/trend_pipeline/llm_refiner.py`
- `app/trend_pipeline/latest_feed.py`
- `.env`
- `README.md`

## 확인 사항
- 문법 체크 통과
- `final_web_py311` 환경에서 `chromadb` import 확인
- 현재 로컬에는 `hair_trends` 컬렉션이 없어 `refined_trends_json` fallback으로 동작하는 것 확인
- RunPod `latest_trends` 액션 미구현 시 기존 동작이 깨지지 않고 fallback 유지 확인
