### PR TITLE
feat: 디자이너 챗봇에 LangChain 적용 및 README 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 AI 기반 퍼스널 헤어 스타일 분석 및 추천 솔루션, **MirrAI** 프로젝트 저장소입니다.  
 고객의 페이스 라인 분석과 개인별 스타일 취향을 결합하여 최적의 헤어스타일을 제안하고, 디자이너와의 스마트한 상담 환경을 제공합니다.
 
-현재 구조는 **Django (MVT)** 아키텍처를 중심으로 동작하며, 로컬 개발 환경에서는 **ChromaDB 기반 RAG**, **자동 트렌드 스케줄러**, **디자이너 챗봇**까지 함께 검증할 수 있습니다.
+현재 구조는 **Django (MVT)** 아키텍처를 중심으로 동작하며, 로컬 개발 환경에서는 **LangChain + ChromaDB 기반 RAG**, **자동 트렌드 스케줄러**, **디자이너 챗봇**까지 함께 검증할 수 있습니다.
 
 ---
 
@@ -72,7 +72,7 @@ MirrAI는 매장 중심의 B2B2C 서비스 구조를 채택합니다.
 
 ```text
 .
-├── app/                    # 비즈니스 로직, API(v1), 서비스, 테스트
+├── app/                    # 비즈니스 로직, API(v1), 서비스
 ├── mirrai_project/         # Django 프로젝트 설정
 ├── static/                 # 정적 자산
 ├── templates/              # HTML 템플릿
@@ -120,19 +120,7 @@ Copy-Item .env.example .env
 - `MIRRAI_MODEL_CHATBOT_OPENAI_MODEL=gpt-4.1-mini`
 - `MIRRAI_MODEL_CHATBOT_API_KEY=<your OpenAI API key>`
 
-### 3) 테스트 데이터 생성
-
-```bash
-python manage.py seed_test_accounts
-```
-
-추가 대량 테스트 데이터가 필요하면:
-
-```bash
-python seed_100_data.py
-```
-
-### 4) 서버 실행
+### 3) 서버 실행
 
 ```bash
 python manage.py runserver
@@ -144,7 +132,7 @@ Windows에서는 아래 배치 파일로도 실행할 수 있습니다.
 run_server.bat
 ```
 
-### 5) 자동 스케줄러
+### 4) 자동 스케줄러
 
 현재는 `.env` 의 `ENABLE_TREND_SCHEDULER=true` 인 상태에서 Django 서버가 시작되면 트렌드 스케줄러도 함께 자동 시작됩니다.
 
@@ -157,49 +145,6 @@ run_server.bat
 ```bash
 python manage.py run_trend_scheduler
 ```
-
----
-
-## 🧪 바로 테스트하기
-
-### 1. 관리자 로그인
-
-`python manage.py seed_test_accounts` 실행 후 아래 계정으로 로그인할 수 있습니다.
-
-- 로그인 페이지: `http://localhost:8000/partner/login/`
-- 관리자 전화번호: `01080001000`
-- 관리자 비밀번호: `1234`
-
-### 2. 디자이너 세션 진입
-
-디자이너 챗봇을 가장 빠르게 확인하는 방법입니다.
-
-1. 관리자 계정으로 로그인
-2. `http://localhost:8000/partner/designer-select/` 이동
-3. 디자이너 선택
-4. 아래 PIN 중 하나 입력
-   - `2468`
-   - `1357`
-5. `http://localhost:8000/partner/staff/` 로 이동되면 챗봇 확인 가능
-
-### 3. 챗봇이 보이는 페이지
-
-- 디자이너 대시보드: `http://localhost:8000/partner/staff/`
-- 파트너 고객 상세: `http://localhost:8000/partner/customer-detail/<client_id>/`
-- 고객 상담 완료 페이지: `http://localhost:8000/customer/consultation/complete/`
-
-예시 질문:
-
-- `볼륨매직 후 관리 방법 알려줘`
-- `허쉬컷 상담 문구 알려줘`
-
-현재 챗봇 라우팅 순서:
-
-- `openai_responses`
-- `chatbot_rag` 로컬 Chroma 근거 검색
-- OpenAI 호출이 실패하면 안내용 fallback 응답
-
----
 
 ## 🔄 최신 트렌드 / RAG 동작
 
@@ -240,45 +185,25 @@ crawl -> refine -> llm_refine -> vectorize -> rebuild_ncs -> rebuild_styles
 - 데이터셋: `app/data/chatbot/designer_support_dataset_v5_final_revised_optimized.json`
 - 프롬프트 템플릿: `app/data/chatbot/designer_instructor_persona.md`
 - 로컬 Chroma 저장소: `data/rag/stores/chromadb_chatbot/`
+- 저장 클라이언트: `app/trend_pipeline/chroma_client.py` 의 `chromadb.PersistentClient(...)`
+- 저장소 루트: `app/trend_pipeline/paths.py` 의 `data/rag/stores/`
 - 응답 엔진: `app/services/chatbot/service.py`
 - RAG 엔진: `app/services/chatbot/rag.py`
 - 프롬프트 빌더: `app/services/chatbot/prompt_builder.py`
+- LangChain 구성: `langchain-openai`, `langchain-chroma`, `langchain-core`
 
 최근 정리 내용:
 
 - 인사/감사/짧은 질문은 섹션 제목 없이 자연스럽게 응답합니다.
 - 일반 시술 질문은 강사처럼 핵심 설명과 체크 포인트를 나눠서 안내합니다.
-- RAG 랭킹은 질문 토큰 정규화, 조사 제거, 주제별 보너스/패널티, 노이즈 문서 필터를 함께 사용합니다.
+- RAG 검색은 질문 토큰 정규화, 조사 제거, 벡터 검색과 어휘 중첩 점수 병합, 지시문 형태 문서 필터를 함께 사용합니다.
 - 예를 들어 `염색 전 주의사항` 질문은 가발 자료보다 패치 테스트, 알레르기, 두피 상태 관련 문서를 우선 참조합니다.
+- 사용자 질문, 클라이언트 측 대화 기록, 검색된 문서 내용은 모두 신뢰하지 않는 입력으로 취급합니다.
+- 시스템 프롬프트 공개나 내부 규칙 무시 요청은 차단하고, 디자이너 이름/역할 변경 요청은 현재 세션 정보를 기준으로만 응답합니다.
+- 검색 문서나 이전 대화에 지시문 형태 문장이 섞여 있으면 프롬프트 구성 전에 제외하거나 마스킹합니다.
+- 응답 생성은 `langchain_openai` 기반 `openai_responses` 가 담당하고, `langchain_chroma` 기반 `chatbot_rag` 는 로컬 근거 검색에 사용됩니다. OpenAI 호출 실패 시에는 안내용 fallback 응답으로 전환합니다.
 
 위 Chroma 저장소와 manifest 파일은 로컬 생성물이므로 Git에서는 무시합니다.
-
----
-
-## 🧪 자주 쓰는 테스트 명령
-
-핵심 테스트:
-
-```bash
-python manage.py test app.tests.test_chatbot_prompt_builder
-python manage.py test app.tests.test_chatbot_rag
-python manage.py test app.tests.test_chatbot_service
-python manage.py test app.tests.test_latest_feed
-python manage.py test app.tests.test_vectorize_chromadb
-python manage.py test app.tests.test_ai_facade
-```
-
-한 번에 실행:
-
-```bash
-python manage.py test ^
-  app.tests.test_chatbot_prompt_builder ^
-  app.tests.test_chatbot_rag ^
-  app.tests.test_chatbot_service ^
-  app.tests.test_latest_feed ^
-  app.tests.test_vectorize_chromadb ^
-  app.tests.test_ai_facade
-```
 
 ---
 
@@ -355,6 +280,9 @@ python manage.py test ^
 - 민감한 값은 `.env` 및 외부 시크릿 저장소를 통해 관리
 - 정적 파일은 WhiteNoise 기반 서빙
 - 로컬 생성물과 런타임 산출물은 `.gitignore`, `.dockerignore` 로 분리
+- 챗봇은 프롬프트 유출과 지침 무시 요청을 보안 이벤트로 취급하고 차단하며, 역할/이름 변경 요청은 세션 정보 기준으로만 응답
+- 사용자 입력, 클라이언트 대화 로그, RAG 검색 결과는 모두 비신뢰 입력으로 다루고 프롬프트에 넣기 전 필터링
+- ChromaDB 저장소는 Supabase가 아니라 로컬 경로 `data/rag/stores/` 아래에 영속 저장
 
 ---
 
@@ -403,4 +331,4 @@ python manage.py test ^
 - `data/rag/`
 - 로컬 로그 및 생성 스토리지
 
-즉, 로컬 Chroma 저장소, raw trend 캐시, manifest, 임시 실행 산출물은 Git에 올라가지 않고, 실제 소스/문서/테스트 파일은 계속 관리 대상입니다.
+즉, 로컬 Chroma 저장소, raw trend 캐시, manifest, 임시 실행 산출물은 Git에 올라가지 않고, 실제 소스와 문서는 계속 관리 대상입니다.

--- a/app/services/chatbot/rag.py
+++ b/app/services/chatbot/rag.py
@@ -13,6 +13,9 @@ from typing import Any
 
 import chromadb
 from chromadb.errors import NotFoundError
+from langchain_chroma import Chroma
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
 
 from .prompt_builder import DESIGNER_INSTRUCTOR_PERSONA_PATH
 from app.trend_pipeline.chroma_client import create_persistent_client
@@ -232,6 +235,16 @@ def _embed_text(value: str) -> list[float]:
     return [item / norm for item in vector]
 
 
+class _HashedTokenEmbeddings(Embeddings):
+    """Wrap the existing local embedding logic in the LangChain interface."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [_embed_text(text) for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return _embed_text(text)
+
+
 def _manifest_payload() -> dict[str, Any]:
     if not CHATBOT_RAG_DATASET_PATH.exists():
         return {}
@@ -353,6 +366,15 @@ def _create_client() -> chromadb.PersistentClient:
     return create_persistent_client(CHATBOT_RAG_CHROMA_DIR)
 
 
+def _create_vector_store() -> Chroma:
+    return Chroma(
+        client=_create_client(),
+        collection_name=CHATBOT_RAG_COLLECTION_NAME,
+        embedding_function=_HashedTokenEmbeddings(),
+        create_collection_if_not_exists=True,
+    )
+
+
 def _reset_collection() -> None:
     if CHATBOT_RAG_CHROMA_DIR.exists():
         shutil.rmtree(CHATBOT_RAG_CHROMA_DIR, ignore_errors=True)
@@ -369,15 +391,18 @@ def ensure_chatbot_rag_index() -> int:
                 pass
 
         _reset_collection()
-        client = _create_client()
-        collection = client.create_collection(CHATBOT_RAG_COLLECTION_NAME)
+        vector_store = _create_vector_store()
         documents = _build_rag_documents()
         if documents:
-            collection.add(
-                ids=[item["id"] for item in documents],
-                documents=[item["document"] for item in documents],
-                metadatas=[item["metadata"] for item in documents],
-                embeddings=[_embed_text(item["document"]) for item in documents],
+            vector_store.add_documents(
+                documents=[
+                    Document(
+                        page_content=str(item["document"] or ""),
+                        metadata=dict(item["metadata"] or {}),
+                    )
+                    for item in documents
+                ],
+                ids=[str(item["id"]) for item in documents],
             )
         _write_manifest()
         return len(documents)
@@ -386,37 +411,21 @@ def ensure_chatbot_rag_index() -> int:
 def _query_collection(question: str, *, limit: int) -> list[dict[str, Any]]:
     try:
         ensure_chatbot_rag_index()
-        client = _create_client()
-        collection = client.get_collection(CHATBOT_RAG_COLLECTION_NAME)
-        query_result = collection.query(
-            query_embeddings=[_embed_text(question)],
-            n_results=limit,
-            include=["documents", "metadatas", "distances"],
-        )
+        results = _create_vector_store().similarity_search_with_score(question, k=limit)
     except Exception as exc:
         logger.warning("[chatbot_rag_chroma_retry] reason=%s", exc)
         ensure_chatbot_rag_index()
-        client = _create_client()
-        collection = client.get_collection(CHATBOT_RAG_COLLECTION_NAME)
-        query_result = collection.query(
-            query_embeddings=[_embed_text(question)],
-            n_results=limit,
-            include=["documents", "metadatas", "distances"],
-        )
-
-    documents = (query_result.get("documents") or [[]])[0]
-    metadatas = (query_result.get("metadatas") or [[]])[0]
-    distances = (query_result.get("distances") or [[]])[0]
+        results = _create_vector_store().similarity_search_with_score(question, k=limit)
 
     matches: list[dict[str, Any]] = []
-    for document, metadata, distance in zip(documents, metadatas, distances):
-        if not document or not isinstance(metadata, dict):
+    for document, distance in results:
+        if not document.page_content or not isinstance(document.metadata, dict):
             continue
         score = max(0.0, 1.0 - float(distance or 0.0))
         matches.append(
             {
-                "document": str(document),
-                "metadata": metadata,
+                "document": str(document.page_content),
+                "metadata": document.metadata,
                 "score": score,
             }
         )

--- a/app/services/chatbot/service.py
+++ b/app/services/chatbot/service.py
@@ -5,8 +5,11 @@ import os
 import re
 from typing import Any
 
-import requests
 from django.utils import timezone
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+from openai import APIStatusError, APITimeoutError, OpenAIError
 
 from .prompt_builder import (
     build_designer_instructor_system_prompt,
@@ -19,8 +22,6 @@ from .rag import (
 
 
 logger = logging.getLogger(__name__)
-
-OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 DEFAULT_OPENAI_CHATBOT_MODEL = "gpt-4.1-mini"
 DEFAULT_OPENAI_CHATBOT_FALLBACK_MODEL = ""
 DEFAULT_OPENAI_CHATBOT_MAX_OUTPUT_TOKENS = 2048
@@ -572,128 +573,133 @@ def _build_openai_instructions(
     ).strip()
 
 
-def _build_openai_request_payload(
+def _build_openai_prompt_messages(
     *,
-    model: str,
     message: str,
     rag_context: dict[str, Any],
     admin_name: str | None = None,
     store_name: str | None = None,
     conversation_history: list[dict[str, Any]] | None = None,
+    ) -> list[BaseMessage]:
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                _build_openai_instructions(
+                    rag_context=rag_context,
+                    admin_name=admin_name,
+                    store_name=store_name,
+                ),
+            ),
+            ("human", "{user_context}"),
+        ]
+    )
+    return prompt.format_messages(
+        user_context=_build_user_context_message(
+            latest_message=message,
+            conversation_history=conversation_history,
+            rag_context=rag_context,
+        )
+    )
+
+
+def _build_openai_chat_model_kwargs(
+    *,
+    model: str,
     include_reasoning_summary: bool = True,
 ) -> dict[str, Any]:
-    text_config: dict[str, Any] = {
-        "format": {"type": "text"},
+    model_kwargs: dict[str, Any] = {
+        "text": {"format": {"type": "text"}},
     }
-    request_payload: dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "model": model,
-        "instructions": _build_openai_instructions(
-            rag_context=rag_context,
-            admin_name=admin_name,
-            store_name=store_name,
-        ),
-        "input": [
-            {
-                "role": "user",
-                "content": _build_user_context_message(
-                    latest_message=message,
-                    conversation_history=conversation_history,
-                    rag_context=rag_context,
-                ),
-            }
-        ],
-        "max_output_tokens": _openai_chatbot_max_output_tokens(),
+        "api_key": _openai_api_key(),
+        "timeout": float(_model_chatbot_timeout()[1]),
+        "max_retries": 0,
+        "use_responses_api": True,
+        "max_tokens": _openai_chatbot_max_output_tokens(),
         "store": _openai_chatbot_store(),
-        "text": text_config,
+        "model_kwargs": model_kwargs,
     }
 
     if _is_reasoning_model(model):
-        request_payload["reasoning"] = {
+        reasoning: dict[str, Any] = {
             "effort": _openai_chatbot_reasoning_effort(),
         }
         if include_reasoning_summary:
-            request_payload["reasoning"]["summary"] = _openai_chatbot_reasoning_summary()
-        text_config["verbosity"] = _openai_chatbot_verbosity()
+            reasoning["summary"] = _openai_chatbot_reasoning_summary()
+        kwargs["reasoning"] = reasoning
+        kwargs["verbosity"] = _openai_chatbot_verbosity()
     else:
-        request_payload["temperature"] = _openai_chatbot_temperature()
-        request_payload["top_p"] = _openai_chatbot_top_p()
+        kwargs["temperature"] = _openai_chatbot_temperature()
+        kwargs["top_p"] = _openai_chatbot_top_p()
 
-    return request_payload
+    return kwargs
 
 
-def _extract_reasoning_summary(payload: dict[str, Any]) -> str | None:
-    output = payload.get("output")
-    if not isinstance(output, list):
-        return None
+def _create_openai_chat_model(
+    *,
+    model: str,
+    include_reasoning_summary: bool = True,
+) -> ChatOpenAI:
+    return ChatOpenAI(
+        **_build_openai_chat_model_kwargs(
+            model=model,
+            include_reasoning_summary=include_reasoning_summary,
+        )
+    )
 
+
+def _extract_reasoning_summary(response: AIMessage) -> str | None:
     summaries: list[str] = []
-    for item in output:
-        if not isinstance(item, dict) or item.get("type") != "reasoning":
+    for block in getattr(response, "content_blocks", None) or []:
+        if not isinstance(block, dict) or block.get("type") != "reasoning":
             continue
-        for summary_item in item.get("summary") or []:
-            if not isinstance(summary_item, dict):
-                continue
-            if summary_item.get("type") != "summary_text":
-                continue
-            text = summary_item.get("text")
-            if isinstance(text, str) and text.strip():
-                summaries.append(text.strip())
+
+        reasoning_text = block.get("reasoning")
+        if isinstance(reasoning_text, str) and reasoning_text.strip():
+            summaries.append(reasoning_text.strip())
+            continue
+
+        summary_text = block.get("summary")
+        if isinstance(summary_text, str) and summary_text.strip():
+            summaries.append(summary_text.strip())
+            continue
+
+        if isinstance(summary_text, list):
+            for item in summary_text:
+                if not isinstance(item, dict):
+                    continue
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    summaries.append(text.strip())
 
     if not summaries:
         return None
     return _normalize_reply_text("\n\n".join(summaries))
 
 
-def _extract_openai_reply(payload: dict[str, Any]) -> str | None:
-    output = payload.get("output")
-    if isinstance(output, list):
-        text_parts: list[str] = []
-        for item in output:
-            if not isinstance(item, dict):
-                continue
-            if item.get("type") != "message":
-                continue
-            if item.get("role") != "assistant":
-                continue
-            content = item.get("content")
-            if isinstance(content, str):
-                text_parts.append(content)
-                continue
-            if not isinstance(content, list):
-                continue
-            for part in content:
-                if not isinstance(part, dict):
-                    continue
-                if part.get("type") not in {"output_text", "text"}:
-                    continue
-                text_value = part.get("text")
-                if isinstance(text_value, str):
-                    text_parts.append(text_value)
-        if text_parts:
-            return _normalize_reply_text("\n".join(text_parts))
+def _extract_openai_reply(response: AIMessage | Any) -> str | None:
+    text = getattr(response, "text", None)
+    if isinstance(text, str) and text.strip():
+        return _normalize_reply_text(text)
 
-    choices = payload.get("choices")
-    if not isinstance(choices, list) or not choices:
-        return None
-
-    first_choice = choices[0] if isinstance(choices[0], dict) else {}
-    message = first_choice.get("message") if isinstance(first_choice, dict) else {}
-    if not isinstance(message, dict):
-        return None
-
-    content = message.get("content")
-    if isinstance(content, str):
+    content = getattr(response, "content", None)
+    if isinstance(content, str) and content.strip():
         return _normalize_reply_text(content)
 
     if isinstance(content, list):
-        text_parts = []
+        text_parts: list[str] = []
         for item in content:
+            if isinstance(item, str) and item.strip():
+                text_parts.append(item)
+                continue
             if not isinstance(item, dict):
                 continue
-            if item.get("type") != "text":
+            if item.get("type") not in {"text", "output_text"}:
                 continue
             text_value = item.get("text")
-            if isinstance(text_value, str):
+            if isinstance(text_value, str) and text_value.strip():
                 text_parts.append(text_value)
         if text_parts:
             return _normalize_reply_text("\n".join(text_parts))
@@ -726,46 +732,37 @@ def _request_openai_response(
     include_reasoning_summary: bool = True,
     allow_timeout_retry: bool = True,
 ) -> dict[str, Any] | None:
-    request_payload = _build_openai_request_payload(
-        model=model,
+    prompt_messages = _build_openai_prompt_messages(
         message=message,
         rag_context=rag_context,
         admin_name=admin_name,
         store_name=store_name,
         conversation_history=conversation_history,
-        include_reasoning_summary=include_reasoning_summary,
     )
 
     try:
-        response = requests.post(
-            OPENAI_RESPONSES_URL,
-            json=request_payload,
-            headers={
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {_openai_api_key()}",
-            },
-            timeout=_model_chatbot_timeout(),
-        )
-        response.raise_for_status()
-        payload = response.json() if response.content else {}
-        response_payload = payload if isinstance(payload, dict) else {}
-        reply_text = _extract_openai_reply(response_payload)
+        response = _create_openai_chat_model(
+            model=model,
+            include_reasoning_summary=include_reasoning_summary,
+        ).invoke(prompt_messages)
+        reply_text = _extract_openai_reply(response)
         if not reply_text:
             logger.warning(
                 "[openai_chatbot_invalid_payload] model=%s payload_type=%s",
                 model,
-                type(payload).__name__,
+                type(response).__name__,
             )
             return None
 
+        response_metadata = getattr(response, "response_metadata", {}) or {}
         return {
             "reply": reply_text,
-            "model": model,
-            "response_id": response_payload.get("id"),
-            "reasoning_summary": _extract_reasoning_summary(response_payload),
+            "model": str(response_metadata.get("model_name") or model),
+            "response_id": getattr(response, "id", None) or response_metadata.get("id"),
+            "reasoning_summary": _extract_reasoning_summary(response),
         }
-    except requests.HTTPError as exc:
-        status_code = exc.response.status_code if exc.response is not None else None
+    except APIStatusError as exc:
+        status_code = getattr(exc, "status_code", None)
         if _is_reasoning_model(model) and include_reasoning_summary and status_code == 400:
             logger.warning(
                 "[openai_chatbot_reasoning_summary_retry] model=%s status=%s",
@@ -788,7 +785,7 @@ def _request_openai_response(
             exc,
         )
         return None
-    except requests.ReadTimeout as exc:
+    except APITimeoutError as exc:
         if allow_timeout_retry:
             logger.warning(
                 "[openai_chatbot_timeout_retry] model=%s timeout=%s",
@@ -811,7 +808,14 @@ def _request_openai_response(
             exc,
         )
         return None
-    except (requests.RequestException, ValueError) as exc:
+    except (OpenAIError, ValueError, TypeError) as exc:
+        logger.warning(
+            "[openai_chatbot_unavailable] model=%s reason=%s",
+            model,
+            exc,
+        )
+        return None
+    except Exception as exc:
         logger.warning(
             "[openai_chatbot_unavailable] model=%s reason=%s",
             model,
@@ -841,6 +845,7 @@ def _build_openai_success_payload(
         "matched_sources": list(rag_context.get("matched_sources") or []),
         "dataset_source": str(rag_context.get("dataset_source") or "chatbot_rag_chromadb"),
         "provider": "openai_responses",
+        "orchestration": "langchain",
         "requested_model": requested_model,
         "used_model": attempt["model"],
         "quality_fallback_used": fallback_reason == "quality",
@@ -956,6 +961,9 @@ def get_chatbot_backend_status() -> dict[str, Any]:
     )
     return {
         "architecture": "openai_rag",
+        "orchestration": "langchain",
+        "chat_model_backend": "langchain_openai",
+        "vectorstore_backend": "langchain_chroma",
         "provider_priority": provider_order[0],
         "provider_order": provider_order,
         "remote_configured": False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,10 @@ fastapi>=0.111,<0.116
 uvicorn>=0.30,<0.31
 python-multipart>=0.0.9,<0.1
 SQLAlchemy>=2.0,<2.1
+openai>=2.26,<3.0
+langchain-core>=1.2,<1.3
+langchain-openai>=1.1,<1.2
+langchain-chroma>=1.1,<1.2
 
 # --- 보안 및 인증 ---
 python-jose[cryptography]>=3.3,<3.4
@@ -35,5 +39,5 @@ apscheduler==3.10.4
 beautifulsoup4==4.12.3
 playwright>=1.49,<2.0
 google-genai>=1.0,<2.0
-chromadb>=0.5,<0.7
+chromadb>=1.3,<2.0
 sentence-transformers>=3.0,<4.0


### PR DESCRIPTION
## 변경 내용

### 1. 디자이너 챗봇 LangChain 적용
- OpenAI 챗봇 호출 경로를 직접 `requests.post` 하는 방식에서 `langchain_openai.ChatOpenAI` 기반으로 정리했습니다.
- 프롬프트 구성은 `ChatPromptTemplate` 기반으로 바꿔서 시스템 지침과 사용자 컨텍스트를 더 명확하게 분리했습니다.
- 챗봇 응답 메타데이터에 `orchestration=langchain`, `chat_model_backend=langchain_openai`, `vectorstore_backend=langchain_chroma` 정보를 반영했습니다.

### 2. 챗봇 RAG를 LangChain Chroma로 정리
- 기존 로컬 해시 임베딩 로직을 `langchain_core.embeddings.Embeddings` 인터페이스로 감싸서 재사용하도록 변경했습니다.
- 챗봇 RAG 인덱싱/조회 경로를 `langchain_chroma.Chroma` 기반으로 정리했습니다.
- 문서 적재는 `Document` 객체 기반으로 맞추고, 검색은 `similarity_search_with_score` 기준으로 동작하도록 변경했습니다.
- 챗봇 Chroma 저장소는 계속 로컬 `data/rag/stores/chromadb_chatbot/` 를 사용합니다.

### 3. 의존성 및 문서 업데이트
- `requirements.txt` 에 `openai`, `langchain-core`, `langchain-openai`, `langchain-chroma` 를 추가했습니다.
- `chromadb` 버전을 LangChain 연동 기준에 맞게 업데이트했습니다.
- README 실행 가이드를 서버/스케줄러 중심으로 정리했고, 챗봇 보안 흐름 및 LangChain + ChromaDB 기반 구조 설명을 현재 구현 기준으로 업데이트했습니다.
- README에 ChromaDB가 Supabase가 아니라 로컬 경로를 사용한다는 점도 명시했습니다.

## 참고
- 응답 생성: `openai_responses`
- 근거 검색: `chatbot_rag`
- OpenAI 호출 실패 시 안내용 fallback 응답으로 전환
