### PR TITLE
설문 제출 이후 비동기 헤어스타일 생성 파이프라인 분리

### DIFF
--- a/app/api/v1/django_views.py
+++ b/app/api/v1/django_views.py
@@ -32,6 +32,7 @@ from app.api.v1.services_django import (
     get_trend_recommendations,
     regenerate_recommendation_simulation,
     retry_current_recommendations,
+    run_hairstyle_generation_pipeline,
     run_mirrai_analysis_pipeline,
     serialize_capture_status,
     upsert_survey,
@@ -210,6 +211,16 @@ class SurveyView(CompatEnvelopeAPIView):
         client = _get_client_or_404(client_id)
         survey = upsert_survey(client, request.data)
         logger.info("[survey_saved] client_id=%s survey_id=%s", client.id, survey.id)
+
+        # Phase 2: 비동기 — 백그라운드에서 헤어스타일 생성
+        thread = threading.Thread(
+            target=run_hairstyle_generation_pipeline,
+            args=(client, survey),
+            daemon=True,
+        )
+        thread.start()
+        logger.info("[survey_saved] hairstyle pipeline started. client_id=%s", client.id)
+
         return Response(SurveySerializer(survey).data)
 
 

--- a/app/api/v1/services_django.py
+++ b/app/api/v1/services_django.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import time
 import uuid
 from collections import Counter
 from types import SimpleNamespace
@@ -25,6 +26,7 @@ from app.models_model_team import (
 from app.services.age_profile import build_client_age_profile, client_matches_age_profile
 from app.services.capture_validation import infer_capture_reason_code
 from app.services.ai_facade import (
+    analyze_face_with_runpod,
     generate_recommendation_batch,
     get_ai_runtime_config_snapshot,
     simulate_face_analysis,
@@ -57,6 +59,7 @@ from app.services.model_team_bridge import (
 )
 from app.services.storage_service import (
     build_storage_snapshot,
+    persist_analysis_input_image_reference,
     persist_simulation_image_reference,
     resolve_storage_reference,
 )
@@ -3027,9 +3030,12 @@ def cancel_style_selection(
 
 
 def run_mirrai_analysis_pipeline(record_id: int, processed_bytes: bytes | None = None):
+    """Phase 1: Store image + call RunPod analyze_face → save face analysis to DB. No hairstyle generation."""
+    logger.info("[PIPELINE THREAD] Record %s started. has_processed_bytes=%s", record_id, bool(processed_bytes))
     try:
         record = mark_legacy_capture_processing(record_id=record_id)
         if record is None or record.status != "PROCESSING":
+            logger.warning("[PIPELINE THREAD] Record %s early exit. record_found=%s", record_id, record is not None)
             return
 
         storage_snapshot = build_storage_snapshot(
@@ -3045,73 +3051,144 @@ def run_mirrai_analysis_pipeline(record_id: int, processed_bytes: bytes | None =
             storage_snapshot["path_count"],
         )
 
-        resolved_analysis_input_reference = resolve_storage_reference(record.processed_path)
-        analysis_input_url = (
-            resolved_analysis_input_reference
-            if str(resolved_analysis_input_reference or "").startswith(("http://", "https://"))
-            else None
+        # Step 1: Store processed image to Supabase for later use at survey time
+        analysis_input_reference = persist_analysis_input_image_reference(
+            processed_bytes,
+            extension=".jpg",
+            mime_type="image/jpeg",
+        ) if processed_bytes else (record.processed_path or record.original_path)
+        logger.info(
+            "[PIPELINE] Record %s image stored. analysis_input_reference=%s",
+            record_id,
+            bool(analysis_input_reference),
         )
-        analysis_input_base64 = (
-            base64.b64encode(processed_bytes).decode("ascii")
-            if processed_bytes
-            else None
-        )
-        survey = get_latest_survey(record.client) or build_default_survey_context(record.client_id)
-        precomputed_items = generate_recommendation_batch(
-            client_id=record.client.id,
-            survey_data={
-                "target_length": getattr(survey, "target_length", None),
-                "target_vibe": getattr(survey, "target_vibe", None),
-                "scalp_type": getattr(survey, "scalp_type", None),
-                "hair_colour": getattr(survey, "hair_colour", None),
-                "budget_range": getattr(survey, "budget_range", None),
-            },
-            analysis_data={
-                "face_shape": None,
-                "golden_ratio_score": None,
-                "image_url": analysis_input_url,
-                "image_base64": analysis_input_base64,
-                "landmark_snapshot": record.landmark_snapshot,
-            },
-            styles_by_id=ensure_catalog_styles(),
-        )
-        analysis_payload = _analysis_payload_from_items(
-            items=precomputed_items,
-            fallback_landmark_snapshot=record.landmark_snapshot,
-        )
-        if analysis_payload is None:
-            runpod_direct_outcome = _runpod_direct_outcome_from_items(items=precomputed_items)
-            if runpod_direct_outcome and runpod_direct_outcome.get("status") == "skipped" and runpod_direct_outcome.get("reason") == "missing_required_payload":
-                raise RuntimeError("RunPod direct input is missing; capture analysis cannot continue.")
-            if runpod_direct_outcome and runpod_direct_outcome.get("status") == "failed":
-                raise RuntimeError(
-                    f"RunPod direct request failed ({runpod_direct_outcome.get('reason') or 'unknown'}); capture analysis cannot continue."
-                )
-            raise RuntimeError("RunPod direct metadata is missing from recommendation output; capture analysis cannot continue.")
 
+        # Step 2: Call RunPod action=analyze_face (warm up cold start + get face data)
+        face_result = analyze_face_with_runpod(image_bytes=processed_bytes)
+        if face_result:
+            face_shape = face_result["face_shape"]
+            golden_ratio_score = face_result["golden_ratio_score"]
+            logger.info(
+                "[PIPELINE] Record %s RunPod face analysis done. face_shape=%s golden_ratio_score=%s",
+                record_id,
+                face_shape,
+                golden_ratio_score,
+            )
+        else:
+            # Local fallback when RunPod is unavailable
+            face_shape = "Oval"
+            golden_ratio_score = 0.85
+            logger.warning(
+                "[PIPELINE] Record %s RunPod analyze_face unavailable, using local fallback.",
+                record_id,
+            )
+
+        # Step 3: Save face analysis + image reference to DB
         record, analysis = complete_legacy_capture_analysis(
             record_id=record_id,
-            face_shape=analysis_payload["face_shape"],
-            golden_ratio_score=analysis_payload["golden_ratio_score"],
-            landmark_snapshot=(record.landmark_snapshot or analysis_payload.get("landmark_snapshot")),
+            face_shape=face_shape,
+            golden_ratio_score=golden_ratio_score,
+            landmark_snapshot=record.landmark_snapshot,
+            analysis_image_url=analysis_input_reference,
         )
         if record is None or analysis is None:
             return
-        if analysis_payload.get("analysis_source"):
-            analysis.analysis_source = analysis_payload.get("analysis_source")
-
-        persist_generated_batch(
-            client=record.client,
-            capture_record=record,
-            survey=survey,
-            analysis=analysis,
-            precomputed_items=precomputed_items,
-        )
 
         sync_model_team_runtime_state(client=record.client)
-        logger.info("[PIPELINE SUCCESS] Record %s processed. storage_mode=%s", record_id, storage_snapshot["storage_mode"])
+        logger.info(
+            "[PIPELINE SUCCESS] Record %s face analysis saved. face_shape=%s has_image_ref=%s",
+            record_id,
+            face_shape,
+            bool(analysis_input_reference),
+        )
 
     except Exception as exc:
         logger.error("[PIPELINE ERROR] Record %s: %s", record_id, exc)
         fail_legacy_capture_processing(record_id=record_id, error_note=str(exc))
+
+
+_HAIRSTYLE_PIPELINE_WAIT_TIMEOUT = 60   # 카메라 파이프라인 완료 최대 대기 시간(초)
+_HAIRSTYLE_PIPELINE_WAIT_INTERVAL = 3  # 재조회 간격(초)
+
+
+def run_hairstyle_generation_pipeline(client: "Client", survey) -> None:
+    """Phase 2: After survey submit, generate hairstyle simulations using face analysis + survey preferences."""
+    client_id = client.id
+    logger.info("[HAIRSTYLE PIPELINE] client_id=%s started.", client_id)
+    try:
+        # 카메라 파이프라인이 아직 실행 중일 수 있으므로 analysis_image_url이 채워질 때까지 대기
+        analysis = None
+        waited = 0
+        while waited <= _HAIRSTYLE_PIPELINE_WAIT_TIMEOUT:
+            analysis = get_latest_analysis(client)
+            if analysis and analysis.image_url:
+                break
+            logger.info(
+                "[HAIRSTYLE PIPELINE] client_id=%s waiting for face analysis... waited=%ss analysis_found=%s image_url=%s",
+                client_id,
+                waited,
+                analysis is not None,
+                repr(getattr(analysis, "image_url", None)),
+            )
+            time.sleep(_HAIRSTYLE_PIPELINE_WAIT_INTERVAL)
+            waited += _HAIRSTYLE_PIPELINE_WAIT_INTERVAL
+
+        if analysis is None:
+            logger.warning("[HAIRSTYLE PIPELINE] client_id=%s no face analysis found after %ss, skipping.", client_id, waited)
+            return
+
+        image_url = resolve_storage_reference(analysis.image_url) if analysis.image_url else None
+        if not image_url:
+            logger.warning(
+                "[HAIRSTYLE PIPELINE] client_id=%s no image URL for analysis (analysis_image_url=%s) after %ss, skipping.",
+                client_id,
+                repr(analysis.image_url),
+                waited,
+            )
+            return
+
+        analysis_data = {
+            "face_shape": analysis.face_shape,
+            "golden_ratio_score": analysis.golden_ratio_score,
+            "image_url": image_url,
+            "landmark_snapshot": analysis.landmark_snapshot,
+        }
+        survey_data = {
+            "target_length": getattr(survey, "target_length", None),
+            "target_vibe": getattr(survey, "target_vibe", None),
+            "scalp_type": getattr(survey, "scalp_type", None),
+            "hair_colour": getattr(survey, "hair_colour", None),
+            "budget_range": getattr(survey, "budget_range", None),
+        }
+        logger.info(
+            "[HAIRSTYLE PIPELINE] client_id=%s calling RunPod. face_shape=%s image_url_set=%s survey_data=%s",
+            client_id,
+            analysis_data.get("face_shape"),
+            bool(image_url),
+            {k: v for k, v in survey_data.items() if v},
+        )
+
+        capture_record = get_latest_capture(client)
+        items = generate_recommendation_batch(
+            client_id=client_id,
+            survey_data=survey_data,
+            analysis_data=analysis_data,
+            styles_by_id=ensure_catalog_styles(),
+        )
+        persist_generated_batch(
+            client=client,
+            capture_record=capture_record,
+            survey=survey,
+            analysis=analysis,
+            precomputed_items=items,
+        )
+        logger.info(
+            "[HAIRSTYLE PIPELINE] client_id=%s done. items=%s simulated=%s",
+            client_id,
+            len(items),
+            sum(1 for item in items if item.get("simulation_image_url")),
+        )
+
+    except Exception as exc:
+        logger.error("[HAIRSTYLE PIPELINE ERROR] client_id=%s: %s", client_id, exc)
 

--- a/app/services/ai_facade.py
+++ b/app/services/ai_facade.py
@@ -611,6 +611,15 @@ def _build_preference_text(survey_data: dict | None) -> str | None:
     return text or None
 
 
+def _build_hairstyle_text(survey_data: dict | None) -> str:
+    survey_data = survey_data or {}
+    parts = [
+        str(survey_data.get("target_length") or "").strip(),
+        str(survey_data.get("target_vibe") or "").strip(),
+    ]
+    return " ".join(part for part in parts if part) or "natural"
+
+
 def _build_runpod_image_payload(analysis_data: dict) -> dict | None:
     image_base64 = str(analysis_data.get("image_base64") or "").strip()
     if image_base64:
@@ -629,11 +638,20 @@ def _build_face_ratios(analysis_data: dict | None) -> dict | None:
     face_bbox = snapshot.get("face_bbox") or {}
     landmarks = snapshot.get("landmarks") or {}
     if not face_bbox:
+        logger.warning(
+            "[face_ratios_failed] reason=no_face_bbox snapshot_keys=%s",
+            sorted(snapshot.keys()),
+        )
         return None
 
     face_height = float(face_bbox.get("height") or 0)
     face_width = float(face_bbox.get("width") or 0)
     if face_height <= 0 or face_width <= 0:
+        logger.warning(
+            "[face_ratios_failed] reason=zero_face_dimensions face_width=%s face_height=%s",
+            face_width,
+            face_height,
+        )
         return None
 
     left_eye = (landmarks.get("left_eye") or {}).get("point")
@@ -641,6 +659,14 @@ def _build_face_ratios(analysis_data: dict | None) -> dict | None:
     mouth_center = (landmarks.get("mouth_center") or {}).get("point")
     chin_center = (landmarks.get("chin_center") or {}).get("point")
     if not (left_eye and right_eye and mouth_center and chin_center):
+        logger.warning(
+            "[face_ratios_failed] reason=missing_landmarks has_left_eye=%s has_right_eye=%s has_mouth=%s has_chin=%s landmark_keys=%s",
+            bool(left_eye),
+            bool(right_eye),
+            bool(mouth_center),
+            bool(chin_center),
+            sorted(landmarks.keys()),
+        )
         return None
 
     eye_distance = dist((left_eye["x"], left_eye["y"]), (right_eye["x"], right_eye["y"]))
@@ -775,25 +801,28 @@ def _augment_items_with_runpod(
     if _ai_provider() != "runpod":
         return items
 
-    image = analysis_data.get("image_url")
-    recommendations_payload = _build_runpod_recommendation_payload(items, analysis_data=analysis_data)
-    if not image or not recommendations_payload:
+    image_payload = _build_runpod_image_payload(analysis_data)
+    if not image_payload:
         return items
 
+    hairstyle_text = _build_hairstyle_text(survey_data)
+    color_text = str((survey_data or {}).get("hair_colour") or "").strip()
+
     runpod_payload = {
-        "image": image,
-        "recommendations": recommendations_payload,
-        "top_k": len(recommendations_payload),
+        **image_payload,
+        "hairstyle_text": hairstyle_text,
+        "top_k": min(len(items), 5),
         "return_base64": True,
     }
-
-    rag_context = _fetch_rag_context_for_items(recommendations_payload)
-    if rag_context:
-        runpod_payload["rag_context"] = rag_context
-
-    color_text = (survey_data or {}).get("hair_colour")
     if color_text:
         runpod_payload["color_text"] = color_text
+
+    logger.info(
+        "[runpod_augment] hairstyle_text=%s color_text=%s top_k=%s",
+        hairstyle_text,
+        color_text or None,
+        runpod_payload["top_k"],
+    )
 
     remote = _post_runpod(runpod_payload)
     if not remote:
@@ -801,13 +830,9 @@ def _augment_items_with_runpod(
 
     results = remote.get("results")
     if not isinstance(results, list) or not results:
+        logger.warning("[runpod_augment] no results in response. remote_keys=%s", sorted(remote.keys()))
         return items
 
-    recommendations = remote.get("recommendations")
-    if not isinstance(recommendations, list):
-        recommendations = recommendations_payload
-
-    rag_context_excerpt = _rag_context_excerpt(remote.get("rag_context"))
     build_tag = str(remote.get("build_tag") or "").strip() or None
     runpod_runtime = remote.get("runpod") if isinstance(remote.get("runpod"), dict) else {}
 
@@ -816,39 +841,61 @@ def _augment_items_with_runpod(
         enriched = dict(item)
         if index < len(results):
             result = results[index] or {}
-            recommendation_meta = _match_runpod_recommendation(
-                recommendations=recommendations,
-                index=index,
-                result=result,
-            )
             image_base64 = result.get("image_base64")
             if image_base64:
                 data_url = f"data:image/png;base64,{image_base64}"
                 enriched["simulation_image_url"] = data_url
                 enriched["synthetic_image_url"] = data_url
             snapshot = dict(enriched.get("reasoning_snapshot") or {})
-            runpod_snapshot = {
+            snapshot["runpod"] = {
                 "provider": "runpod",
                 "clip_score": result.get("clip_score"),
                 "mask_used": result.get("mask_used"),
                 "elapsed_seconds": remote.get("elapsed_seconds"),
-                "recommended_style": result.get("recommended_style"),
                 "build_tag": build_tag,
                 "runtime": runpod_runtime,
-                "rag_context_excerpt": rag_context_excerpt,
             }
-            if recommendation_meta:
-                runpod_snapshot["recommendation"] = recommendation_meta
-                runpod_snapshot["face_shape_detected"] = recommendation_meta.get("face_shape_detected")
-                runpod_snapshot["golden_ratio_score"] = recommendation_meta.get("golden_ratio_score")
-                runpod_snapshot["face_shapes"] = recommendation_meta.get("face_shapes")
-                if recommendation_meta.get("description"):
-                    enriched["llm_explanation"] = enriched.get("llm_explanation") or recommendation_meta.get("description")
-                    enriched["style_description"] = enriched.get("style_description") or recommendation_meta.get("description")
-            snapshot["runpod"] = runpod_snapshot
             enriched["reasoning_snapshot"] = snapshot
         augmented.append(enriched)
+
+    logger.info(
+        "[runpod_augment] done. items=%s simulated=%s",
+        len(augmented),
+        sum(1 for item in augmented if item.get("simulation_image_url")),
+    )
     return augmented
+
+
+def analyze_face_with_runpod(*, image_bytes: bytes | None = None, image_url: str | None = None) -> dict | None:
+    """Call RunPod with action=analyze_face. Returns dict with face_shape/golden_ratio_score or None on failure."""
+    if not _runpod_enabled():
+        return None
+
+    payload: dict = {"action": "analyze_face"}
+    if image_bytes:
+        payload["image_base64"] = base64.b64encode(image_bytes).decode("ascii")
+    elif image_url and image_url.startswith(("http://", "https://")):
+        payload["image_url"] = image_url
+    else:
+        logger.warning("[analyze_face_runpod] no valid image provided — image_bytes=%s image_url=%s", bool(image_bytes), bool(image_url))
+        return None
+
+    remote = _post_runpod(payload)
+    if not remote:
+        logger.warning("[analyze_face_runpod] empty response from RunPod")
+        return None
+
+    face_shape = remote.get("face_shape")
+    golden_ratio_score = remote.get("golden_ratio_score")
+    if not face_shape and golden_ratio_score is None:
+        logger.warning("[analyze_face_runpod] no face data in response. remote_keys=%s", sorted(remote.keys()))
+        return None
+
+    logger.info("[analyze_face_runpod] face_shape=%s golden_ratio_score=%s", face_shape, golden_ratio_score)
+    return {
+        "face_shape": face_shape,
+        "golden_ratio_score": golden_ratio_score,
+    }
 
 
 def simulate_face_analysis(*, image_url: str | None = None, image_bytes: bytes | None = None) -> dict:
@@ -908,6 +955,17 @@ def _attach_runpod_direct_outcome(items: list[dict], outcome: dict | None) -> li
         enriched["reasoning_snapshot"] = reasoning_snapshot
         enriched_items.append(enriched)
     return enriched_items
+
+
+def _runpod_payload_summary(remote: dict) -> dict:
+    recommendations = remote.get("recommendations")
+    results = remote.get("results")
+    return {
+        "remote_keys": sorted(remote.keys()),
+        "recommendation_count": len(recommendations) if isinstance(recommendations, list) else 0,
+        "result_count": len(results) if isinstance(results, list) else 0,
+        "has_traceback": bool(remote.get("traceback") or remote.get("error")),
+    }
 
 
 def _generate_runpod_recommendation_batch_details(
@@ -1004,22 +1062,6 @@ def generate_recommendation_batch(
     scoring_weights = scoring_weights or DEFAULT_SCORING_WEIGHTS
     provider = _ai_provider()
     runpod_direct_outcome = None
-    if provider == "runpod":
-        runpod_direct_outcome = _generate_runpod_recommendation_batch_details(
-            client_id=client_id,
-            survey_data=survey_data,
-            analysis_data=analysis_data,
-            styles_by_id=styles_by_id,
-        )
-        direct_items = runpod_direct_outcome.get("items")
-        if direct_items is not None:
-            logger.info(
-                "[ai_recommendations] provider=runpod remote_success=True client_id=%s item_count=%s direct_primary=True",
-                client_id,
-                len(direct_items),
-            )
-            return direct_items
-
     if provider == "service":
         remote = _request_service(
             "POST",
@@ -1053,12 +1095,10 @@ def generate_recommendation_batch(
         styles_by_id=styles_by_id,
         scoring_weights=scoring_weights,
     )
-    items = _augment_items_with_runpod(items=items, survey_data=survey_data, analysis_data=analysis_data)
+
     if provider == "runpod":
-        items = _attach_runpod_direct_outcome(items, runpod_direct_outcome)
-        augmented_count = sum(
-            1 for item in items if isinstance((item.get("reasoning_snapshot") or {}).get("runpod"), dict)
-        )
+        items = _augment_items_with_runpod(items=items, survey_data=survey_data, analysis_data=analysis_data)
+        augmented_count = sum(1 for item in items if item.get("simulation_image_url"))
         logger.info(
             "[ai_recommendations] provider=runpod client_id=%s item_count=%s augmented_items=%s",
             client_id,

--- a/app/services/face_processing.py
+++ b/app/services/face_processing.py
@@ -215,6 +215,15 @@ def extract_landmark_snapshot(*, processed_bytes: bytes) -> dict:
     )
     primary_face = _largest_face(faces)
     if primary_face is None:
+        equalized = cv2.equalizeHist(gray)
+        relaxed_faces = _FACE_CASCADE.detectMultiScale(
+            equalized,
+            scaleFactor=1.05,
+            minNeighbors=4,
+            minSize=(72, 72),
+        )
+        primary_face = _largest_face(relaxed_faces)
+    if primary_face is None:
         return {
             "version": "coarse-v1",
             "face_count": 0,

--- a/mirrai_project/settings.py
+++ b/mirrai_project/settings.py
@@ -200,3 +200,32 @@ TREND_SCHEDULER_TIMEOUT = env.int("TREND_SCHEDULER_TIMEOUT", default=1800)
 TREND_SCHEDULER_POLL_INTERVAL = env.float("TREND_SCHEDULER_POLL_INTERVAL", default=5.0)
 TREND_SCHEDULER_SLEEP_INTERVAL = env.float("TREND_SCHEDULER_SLEEP_INTERVAL", default=15.0)
 TREND_SCHEDULER_TEST_AT = env("TREND_SCHEDULER_TEST_AT", default="")
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "[{asctime}] {levelname} {name} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        "app": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "django": {
+            "handlers": ["console"],
+            "level": "WARNING",
+            "propagate": False,
+        },
+    },
+}

--- a/templates/customer/result.html
+++ b/templates/customer/result.html
@@ -192,7 +192,30 @@
     let retryMeta = null;
     const customerId = "{{ request.session.customer_id }}";
 
-    async function fetchRecommendations() {
+    // ?fresh=<unix_ts> 파라미터: 설문 제출 직후 이동한 경우 새 결과가 올 때까지 폴링
+    const urlParams = new URLSearchParams(window.location.search);
+    const freshTs = parseInt(urlParams.get('fresh') || '0', 10);  // seconds
+    const POLL_INTERVAL_MS = 4000;
+    const POLL_TIMEOUT_MS = 120000;  // 2분
+    let pollStartedAt = freshTs ? Date.now() : 0;
+    let pollTimer = null;
+
+    function _isNewResult(items) {
+      // 아이템 중 하나라도 freshTs 이후에 생성되었으면 새 결과로 판단
+      if (!freshTs || !items || items.length === 0) return true;
+      return items.some(item => {
+        const createdAt = item.created_at;
+        if (!createdAt) return false;
+        const ts = Math.floor(new Date(createdAt).getTime() / 1000);
+        return ts >= freshTs - 5;  // 5초 여유 (클라이언트-서버 시간 차이 대비)
+      });
+    }
+
+    function _hasSimulationImages(items) {
+      return items && items.some(item => item.simulation_image_url || item.synthetic_image_url);
+    }
+
+    async function fetchRecommendations({ polling = false } = {}) {
       if (!customerId) {
         alert('세션 정보가 없습니다. 다시 시작해 주세요.');
         window.location.href = '/customer/';
@@ -208,14 +231,25 @@
         }
 
         const data = await response.json();
-        if (Array.isArray(data)) {
-          retryMeta = null;
-          renderResults(data);
-          return;
+        const items = Array.isArray(data) ? data : (data.results || data.items || []);
+        if (!Array.isArray(data)) retryMeta = data;
+
+        // 폴링 중: 새 결과(시뮬레이션 이미지 포함)가 올 때까지 기다림
+        if (polling && freshTs) {
+          const elapsed = Date.now() - pollStartedAt;
+          const isNew = _isNewResult(items);
+          const hasImages = _hasSimulationImages(items);
+
+          if ((!isNew || !hasImages) && elapsed < POLL_TIMEOUT_MS) {
+            // 아직 새 결과 없음 → 다시 폴링
+            pollTimer = setTimeout(() => fetchRecommendations({ polling: true }), POLL_INTERVAL_MS);
+            return;
+          }
+          // 타임아웃이거나 새 결과 있음 → 렌더링
+          clearTimeout(pollTimer);
         }
 
-        retryMeta = data;
-        renderResults(data.results || data.items || []);
+        renderResults(items);
       } catch (error) {
         loading.innerHTML = '<p class="section-title" style="color: var(--status-red);">추천 결과를 불러오지 못했습니다.</p>';
       }
@@ -403,7 +437,8 @@
       }
     });
 
-    fetchRecommendations();
+    // ?fresh 파라미터가 있으면 폴링 모드로 시작
+    fetchRecommendations({ polling: Boolean(freshTs) });
   })();
 </script>
 {% endblock %}

--- a/templates/customer/survey.html
+++ b/templates/customer/survey.html
@@ -459,7 +459,10 @@
           body: JSON.stringify(data)
         });
         if (!response.ok) throw new Error("Survey submission failed");
-        window.location.href = isReanalysisFlow ? "/customer/recommendations/?reanalysis=1" : "/customer/recommendations/";
+        const freshTs = Math.floor(Date.now() / 1000);
+        window.location.href = isReanalysisFlow
+          ? `/customer/recommendations/?reanalysis=1&fresh=${freshTs}`
+          : `/customer/recommendations/?fresh=${freshTs}`;
       } catch (error) {
         alert("저장 중 오류가 발생했습니다.");
         submitBtn.disabled = false;


### PR DESCRIPTION
## 변경 내용
  - 캡처 파이프라인이 처리 이미지를 저장하고 RunPod `analyze_face` 결과만 DB에 반영하도록 분리했습니다.
  - 설문 제출 시 백그라운드 헤어스타일 생성 파이프라인을 실행하고, 얼굴 분석 결과가 준비되면 추천/시뮬레이션 배치를 저장하도록 변경했습니다.
  - 결과 페이지에 `fresh` 기반 polling을 추가해 새 추천 결과와 시뮬레이션 이미지가 생성될 때까지 재조회하도록 했습니다.
  - 얼굴 검출 fallback과 애플리케이션 로깅을 보강해 실패 원인 추적성을 높였습니다.

  ## 변경 이유
  - 캡처 단계의 무거운 작업을 줄이고, 설문 응답을 반영한 추천/시뮬레이션 생성을 분리해 사용자 흐름을 안정화하려는 목적입니다.
  - RunPod cold start나 분석 지연이 있어도 결과 페이지에서 신규 결과를 기다릴 수 있도록 보완했습니다.

  ## 테스트
  - [ ] 설문 제출 후 `fresh` 파라미터를 포함한 추천 페이지로 이동하는지 확인
  - [ ] 얼굴 분석 완료 후 추천 결과에 시뮬레이션 이미지가 노출되는지 확인
  - [ ] RunPod 응답 지연 또는 실패 시 fallback/logging이 의도대로 동작하는지 확인
