### PR TITLE
fix: allow EB health checks before host validation

### DIFF
--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,5 +1,25 @@
+from django.http import JsonResponse
 from django.utils.deprecation import MiddlewareMixin
+
 from app.session_state import clear_customer_session, clear_designer_session
+
+
+class ElasticBeanstalkHealthCheckMiddleware(MiddlewareMixin):
+    """
+    Return a lightweight 200 response for ALB/ELB health checks before Django's
+    host validation runs.
+    """
+
+    HEALTH_PATHS = {"/", "/health", "/health/"}
+    HEALTHCHECK_USER_AGENT_PREFIXES = ("ELB-HealthChecker/",)
+
+    def process_request(self, request):
+        user_agent = str(request.META.get("HTTP_USER_AGENT") or "")
+        if request.path not in self.HEALTH_PATHS:
+            return None
+        if not user_agent.startswith(self.HEALTHCHECK_USER_AGENT_PREFIXES):
+            return None
+        return JsonResponse({"status": "django_running", "framework": "Django"})
 
 class BrowserSessionCleanupMiddleware(MiddlewareMixin):
     """

--- a/app/tests/test_eb_healthcheck_middleware.py
+++ b/app/tests/test_eb_healthcheck_middleware.py
@@ -1,0 +1,45 @@
+from django.test import Client, SimpleTestCase, override_settings
+
+
+@override_settings(
+    ALLOWED_HOSTS=["mirrai.shop"],
+    SESSION_ENGINE="django.contrib.sessions.backends.signed_cookies",
+)
+class ElasticBeanstalkHealthCheckMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_elb_healthcheck_root_path_bypasses_host_validation(self):
+        response = self.client.get(
+            "/",
+            HTTP_HOST="10.0.0.10",
+            HTTP_USER_AGENT="ELB-HealthChecker/2.0",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"status": "django_running", "framework": "Django"},
+        )
+
+    def test_non_healthcheck_user_agent_still_rejects_untrusted_host(self):
+        response = self.client.get(
+            "/",
+            HTTP_HOST="10.0.0.10",
+            HTTP_USER_AGENT="Mozilla/5.0",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_elb_healthcheck_health_path_bypasses_host_validation(self):
+        response = self.client.get(
+            "/health/",
+            HTTP_HOST="10.0.0.10",
+            HTTP_USER_AGENT="ELB-HealthChecker/2.0",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"status": "django_running", "framework": "Django"},
+        )

--- a/mirrai_project/settings.py
+++ b/mirrai_project/settings.py
@@ -146,6 +146,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "app.middleware.ElasticBeanstalkHealthCheckMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",


### PR DESCRIPTION
## Summary\n- return a lightweight 200 response for ALB/ELB health probes before Django host validation runs\n- register the health-check middleware ahead of Django security/common middleware\n- add regression tests covering trusted ELB probes and untrusted normal requests\n\n## Why\nElastic Beanstalk showed severe health with 4xx probe failures even though the public app was responding. The ALB health checker can hit the app with an internal Host header, which Django rejects before reaching the existing health view. This patch keeps only ELB health probes green without widening normal host access.\n\n## Test\n- python manage.py test app.tests.test_eb_healthcheck_middleware --verbosity 2