### PR TITLE
fix: AWS Elastic Beanstalk 502 Bad Gateway 에러 방어 및 롱폴링 타임아웃 최적화

### DIFF
--- a/app/api/v1/services_django.py
+++ b/app/api/v1/services_django.py
@@ -109,7 +109,7 @@ RETRY_RECOMMENDATION_POLICY = {
 }
 
 CURRENT_RECOMMENDATION_WAIT_POLICY = RecommendationWaitPolicy(
-    timeout_seconds=120.0,
+    timeout_seconds=45.0,
     interval_seconds=3.0,
 )
 FAILED_RECOMMENDATION_INPUT_STATUSES = {"FAILED", "NEEDS_RETAKE", "ERROR"}


### PR DESCRIPTION
### 🚀 PR 요약: AWS Elastic Beanstalk 502 Bad Gateway 에러 방어 및 롱폴링 타임아웃 최적화

**[문제 원인]**
- 최근 도입된 비동기 AI 헤어스타일 생성 파이프라인 대기 로직(`CURRENT_RECOMMENDATION_WAIT_POLICY`)의 기본 타임아웃이 120초로 설정되어 있었습니다.
- AWS Elastic Beanstalk 환경의 Nginx 리버스 프록시는 Gunicorn(백엔드)이 **60초 동안 대답이 없으면 연결을 끊고 502 Bad Gateway 에러를 반환**하는 기본 정책이 있어, 런팟(RunPod) 콜드 스타트로 로딩이 지연될 경우 프론트엔드 통신이 강제로 단절되는 크리티컬한 문제가 발생했습니다.

**[해결 및 수정 사항]**
- `app/api/v1/services_django.py`의 `RecommendationWaitPolicy` 대기 시간을 120초에서 **`45초`**로 대폭 단축했습니다.
- 이제 서버는 45초까지만 대기 후 `status: "processing"`과 함께 안전하게 응답을 반환하며, 프론트엔드 자바스크립트는 Nginx에서 연결을 끊기 전에 즉각적으로 재요청(Polling)을 시도하게 되어 502 에러가 원천 차단됩니다.
- 덤으로 런팟의 부팅(Cold Start) 대기 시간 동안 오리지널 기본 사진만 Fallback되어 출력되던 빈도도 획기적으로 줄어들게 됩니다.

**[테스트 완료 내역]**
- [x] 프론트엔드 비동기 폴링 렌더링 유지 테스트 완료
- [x] 타임아웃 제한값 45초 축소로 AWS Nginx 정책 (60초) 우회 확인
