### PR TITLE
fix: ChromaDB 배포 이미지 포함 및 트렌드 의존성 충돌 수정

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -28,7 +28,7 @@ SQLAlchemy>=2.0,<2.1
 openai>=2.26,<3.0
 langchain-core>=1.2,<1.3
 langchain-openai>=1.1,<1.2
-langchain-chroma>=1.1,<1.2
+langchain-chroma==0.2.3
 
 # Security and API docs
 python-jose[cryptography]>=3.3,<3.4


### PR DESCRIPTION
## 변경 내용
- Docker 배포 이미지에 `data/rag/stores/**`가 포함되도록 배포 설정 수정
- `data/rag/stores/**` 변경 시 GitHub Actions 배포가 트리거되도록 반영
- 운영 이미지 빌드 시 트렌드/RAG 의존성이 함께 설치되도록 설정
- `langchain-chroma` 버전을 `chromadb 0.6.x`와 호환되는 버전으로 고정해 빌드 충돌 해결

## 배경
운영 환경에서 ChromaDB store가 이미지에 포함되지 않아 최신 트렌드 조회와 챗봇 RAG가 정상 동작하지 않는 문제가 있었습니다.

추가로 배포 빌드 과정에서
- `langchain-chroma 1.1.x`
- `chromadb 0.5~0.6`
조합이 충돌해 Docker 이미지 빌드가 실패하고 있었습니다.

## 기대 효과
- 운영 컨테이너에서 ChromaDB store를 직접 읽을 수 있음
- 최신 트렌드 조회 / 챗봇 RAG가 배포 환경에서도 정상 동작 가능
- Docker 빌드가 의존성 충돌 없이 통과

## 확인 사항
- `python:3.12-slim` 기준 Docker 빌드 통과 확인
- `chromadb 0.6.3` import 정상 확인
