### PR TITLE
build: Docker 배포 이미지 경량화 및 트렌드 빌드 분기 정리

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,20 @@ ENV PYTHONPATH=/app
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    libpq-dev \
-    --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
 COPY requirements.txt requirements-deploy.txt requirements-trends.txt ./
 
 # Production image installs only runtime dependencies by default.
 # If trend-pipeline image is needed, build with:
 #   docker build --build-arg INSTALL_TRENDS_DEPS=1 -t <tag> .
 ARG INSTALL_TRENDS_DEPS=0
-RUN if [ "$INSTALL_TRENDS_DEPS" = "1" ]; then \
+RUN set -eux; \
+    if [ "$INSTALL_TRENDS_DEPS" = "1" ]; then \
+      apt-get update; \
+      apt-get install -y --no-install-recommends build-essential libpq-dev; \
       pip install --no-cache-dir -r requirements-trends.txt; \
-      python -m playwright install --with-deps chromium; \
+      python -m playwright install --with-deps --only-shell chromium; \
+      apt-get purge -y --auto-remove build-essential libpq-dev; \
+      rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /root/.cache/pip; \
     else \
       pip install --no-cache-dir -r requirements-deploy.txt; \
     fi


### PR DESCRIPTION
## 변경 내용
- 기본 배포 이미지에서는 런타임 의존성만 설치하도록 유지
- `INSTALL_TRENDS_DEPS=1`일 때만 `build-essential`, `libpq-dev`, `requirements-trends.txt`를 설치하도록 분기
- Playwright Chromium 설치를 `--only-shell`로 축소
- 트렌드 빌드 이후 build deps와 apt/pip 캐시를 정리하도록 변경

## 기대 효과
- 일반 배포 이미지 크기 감소
- 불필요한 시스템 패키지 상시 포함 방지
- 트렌드 파이프라인이 필요한 경우에만 무거운 의존성 설치
- 빌드 후 잔여 캐시 제거로 이미지 정리
