### PR TITLE
fix(partner): resolve designer MultipleObjectsReturned and dashboard context errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ review/
 detect_encoding.py
 choi_sample/
 architecture.txt
+.playwright-cli/
 
 # Front feedback working folders
 front_feedback/**/past/

--- a/app/api/v1/admin_views.py
+++ b/app/api/v1/admin_views.py
@@ -680,15 +680,15 @@ class LegacyAdminTrendReportView(CompatEnvelopeAPIView):
         admin, designer = staff
 
         days = int(request.query_params.get("days", 7))
-        # Trend reporting is store-wide even when a designer session is active.
-        trend_payload = get_admin_trend_report(days=days, filters={}, admin=admin, designer=None)
-        clients_payload = get_all_clients(admin=admin, designer=None)
+        # Trend reporting now respects designer context if active.
+        trend_payload = get_admin_trend_report(days=days, filters={}, admin=admin, designer=designer)
+        clients_payload = get_all_clients(admin=admin, designer=designer)
         start_date = timezone.localdate() - timezone.timedelta(days=days - 1)
         activity_by_day = get_legacy_activity_client_map_by_day(
             start_date=start_date,
             days=days,
             admin=admin,
-            designer=None,
+            designer=designer,
         )
         if activity_by_day is None:
             activity_by_day = {

--- a/app/dashboard_gate_views.py
+++ b/app/dashboard_gate_views.py
@@ -2,27 +2,44 @@ from __future__ import annotations
 
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.views.decorators.cache import never_cache
 
-from app.front_views import admin_dashboard_page, designer_dashboard_page
+from app.front_views import admin_dashboard_page, admin_mypage_page, designer_dashboard_page
 from app.session_state import (
     can_access_designer_dashboard,
-    can_access_owner_dashboard,
     get_session_admin,
     get_session_designer,
     revoke_designer_dashboard,
 )
 
 
+@never_cache
 def gated_partner_dashboard(request):
+    """파트너 대시보드 게이트.
+
+    매장 세션이 없으면 로그인 페이지로.
+    PIN 인증 여부는 base_site.html의 JS 모달이 클라이언트 측에서 처리.
+    """
     admin = get_session_admin(request=request)
     if admin is None:
         return redirect("partner_index")
-    
-    # 매장 관리자 권한이 있다면 즉시 대시보드 표시
-    # (이미 admin_login 또는 partner_verify 단계에서 allow_owner_dashboard가 호출됨)
     return admin_dashboard_page(request)
 
 
+@never_cache
+def gated_partner_mypage(request):
+    """내 페이지 게이트.
+
+    매장 세션이 없으면 로그인 페이지로.
+    PIN 인증 여부는 base_site.html의 JS 모달이 클라이언트 측에서 처리.
+    """
+    admin = get_session_admin(request=request)
+    if admin is None:
+        return redirect("partner_index")
+    return admin_mypage_page(request)
+
+
+@never_cache
 def gated_partner_staff_dashboard(request):
     designer = get_session_designer(request=request)
     if designer is None:

--- a/app/front_views.py
+++ b/app/front_views.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
-from django.contrib.auth.hashers import check_password, make_password
+from django.contrib.auth.hashers import check_password, identify_hasher, make_password
 from django.http import HttpRequest, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
@@ -36,13 +36,16 @@ from app.services.runtime_cache import (
 )
 from app.session_state import (
     allow_owner_dashboard,
+    allow_owner_mypage,
     can_access_owner_dashboard,
+    can_access_owner_mypage,
     clear_admin_session,
     clear_customer_session,
     clear_designer_session,
     get_session_admin,
     get_session_customer,
     get_session_designer,
+    revoke_all_owner_scopes,
     revoke_owner_dashboard,
     set_admin_session,
     set_customer_session,
@@ -59,6 +62,82 @@ def _normalize_phone(value: str) -> str:
 
 def _normalize_business_number(value: str) -> str:
     return re.sub(r"\D", "", value or "")
+
+
+def _is_hashed_secret(value: str | None) -> bool:
+    normalized = (value or "").strip()
+    if not normalized:
+        return False
+    try:
+        identify_hasher(normalized)
+    except ValueError:
+        return False
+    return True
+
+
+def _hash_admin_pin(value: str) -> str:
+    return make_password(value)
+
+
+def _matches_admin_pin(*, raw_pin: str, stored_pin: str | None) -> bool:
+    normalized_pin = (raw_pin or "").strip()
+    normalized_stored_pin = (stored_pin or "").strip() or "0000"
+    if _is_hashed_secret(normalized_stored_pin):
+        return check_password(normalized_pin, normalized_stored_pin)
+    return normalized_pin == normalized_stored_pin
+
+
+def _is_default_admin_pin(stored_pin: str | None) -> bool:
+    return _matches_admin_pin(raw_pin="0000", stored_pin=stored_pin)
+
+
+def _get_admin_account_for_runtime_admin(admin):
+    from app.models_django import AdminAccount
+
+    runtime_id = str(getattr(admin, "id", "") or "").strip()
+    if runtime_id:
+        if runtime_id.isdigit():
+            admin_obj = AdminAccount.objects.filter(backend_admin_id=int(runtime_id)).first()
+            if admin_obj is not None:
+                return admin_obj
+        else:
+            admin_obj = AdminAccount.objects.filter(id=runtime_id).first()
+            if admin_obj is not None:
+                return admin_obj
+
+    backend_admin_id = getattr(admin, "backend_admin_id", None)
+    if backend_admin_id not in (None, ""):
+        admin_obj = AdminAccount.objects.filter(backend_admin_id=backend_admin_id).first()
+        if admin_obj is not None:
+            return admin_obj
+
+    phone = _normalize_phone(getattr(admin, "phone", ""))
+    if phone:
+        return AdminAccount.objects.filter(phone=phone).order_by("-backend_admin_id").first()
+    return None
+
+
+def _sync_admin_account_state(*, request: HttpRequest, admin_obj) -> None:
+    try:
+        from app.services.model_team_bridge import sync_model_team_admin_state
+
+        sync_model_team_admin_state(admin=admin_obj)
+    except Exception:
+        pass
+    set_admin_session(request=request, admin=admin_obj)
+
+
+def _upgrade_plain_admin_pin_if_needed(*, request: HttpRequest, admin_obj, raw_pin: str) -> bool:
+    stored_pin = (getattr(admin_obj, "admin_pin", "") or "").strip() or "0000"
+    if _is_hashed_secret(stored_pin):
+        return False
+    if stored_pin != raw_pin:
+        return False
+
+    admin_obj.admin_pin = _hash_admin_pin(stored_pin)
+    admin_obj.save(update_fields=["admin_pin"])
+    _sync_admin_account_state(request=request, admin_obj=admin_obj)
+    return True
 
 
 def _birth_year_from_age(age_value: str) -> int | None:
@@ -172,6 +251,9 @@ def health_check(request):
 
 @never_cache
 def home_page(request):
+    # 홈으로 나가면 파트너센터/내 페이지 PIN 인증 세션을 revoke
+    # → 다시 진입할 때 PIN 재인증 필요
+    revoke_all_owner_scopes(request=request)
     return render(request, "index.html", {"start_url": "/customer/", "partner_url": "/partner/login/"})
 
 
@@ -599,56 +681,59 @@ def admin_mypage_page(request):
         return redirect("partner_index")
 
     if request.method == "POST":
+        action = (request.POST.get("action") or "change_pin").strip()
+        admin_obj = _get_admin_account_for_runtime_admin(admin)
+        if admin_obj is None:
+            return JsonResponse({"status": "error", "message": "관리자 정보를 찾을 수 없습니다."}, status=404)
+
+        current_pin = (request.POST.get("current_pin") or "").strip()
+        if not re.fullmatch(r"\d{4}", current_pin):
+            return JsonResponse({"status": "error", "message": "현재 보안키 4자리를 입력해 주세요."}, status=400)
+
+        if not _matches_admin_pin(raw_pin=current_pin, stored_pin=admin_obj.admin_pin):
+            return JsonResponse({"status": "error", "message": "현재 보안키가 일치하지 않습니다."}, status=401)
+
+        _upgrade_plain_admin_pin_if_needed(request=request, admin_obj=admin_obj, raw_pin=current_pin)
+
+        if action == "verify_current_pin":
+            allow_owner_mypage(request=request)
+            return JsonResponse({"status": "success"})
+
+        if action != "change_pin":
+            return JsonResponse({"status": "error", "message": "지원하지 않는 요청입니다."}, status=400)
+
         new_pin = (request.POST.get("admin_pin") or "").strip()
         if not re.fullmatch(r"\d{4}", new_pin):
-            return render(
-                request,
-                "admin/mypage.html",
-                {
-                    "active_shop": admin,
-                    "form_error": "PIN 번호는 4자리 숫자로 입력해 주세요.",
-                },
+            return JsonResponse({"status": "error", "message": "새 보안키는 4자리 숫자로 입력해 주세요."}, status=400)
+
+        if _matches_admin_pin(raw_pin=new_pin, stored_pin=admin_obj.admin_pin):
+            return JsonResponse(
+                {"status": "error", "message": "현재 사용 중인 보안키와 동일합니다. 다른 번호를 입력해 주세요."},
                 status=400,
             )
 
-        # 실제 모델 객체 가져오기 (세션의 SimpleNamespace는 저장 기능이 없음)
-        from app.models_django import AdminAccount
-        try:
-            # backend_admin_id 필드를 사용하여 기존 정수형 ID로 조회
-            admin_obj = AdminAccount.objects.get(backend_admin_id=admin.id)
+        admin_obj.admin_pin = _hash_admin_pin(new_pin)
+        admin_obj.save(update_fields=["admin_pin"])
+        _sync_admin_account_state(request=request, admin_obj=admin_obj)
+        allow_owner_mypage(request=request)
+        return JsonResponse(
+            {
+                "status": "success",
+                "message": "보안키가 성공적으로 변경되었습니다.",
+                "is_default_admin_pin": False,
+            }
+        )
 
-            # 기존 보안키와 동일한지 체크
-            if admin_obj.admin_pin == new_pin:
-                return render(
-                    request,
-                    "admin/mypage.html",
-                    {
-                        "active_shop": admin,
-                        "form_error": "현재 사용 중인 보안키와 동일합니다. 다른 번호를 입력해 주세요.",
-                    },
-                    status=400,
-                )
-
-            admin_obj.admin_pin = new_pin
-            admin_obj.save()
-
-            # 레거시 테이블 동기화 (이미 shop 테이블에 저장했으므로 추가 동기화 시 에러 방지 처리)
-            try:
-                from app.services.model_team_bridge import sync_model_team_admin_state
-                sync_model_team_admin_state(admin=admin_obj)
-            except Exception:
-                # 동기화 중 에러가 나더라도 메인 저장은 성공했으므로 무시
-                pass
-
-            # 세션 정보 갱신
-            set_admin_session(request=request, admin=admin_obj)
-            return JsonResponse(
-                {"status": "success", "message": "보안키가 성공적으로 변경되었습니다."}
-            )
-        except AdminAccount.DoesNotExist:
-            return JsonResponse({"status": "error", "message": "관리자 정보를 찾을 수 없습니다."}, status=404)
-
-    return render(request, "admin/mypage.html", {"active_shop": admin})
+    admin_obj = _get_admin_account_for_runtime_admin(admin)
+    return render(
+        request,
+        "admin/mypage.html",
+        {
+            "active_shop": admin,
+            "is_mypage_owner": can_access_owner_mypage(request=request),
+            "is_default_admin_pin": _is_default_admin_pin(getattr(admin_obj, "admin_pin", None)) if admin_obj else False,
+        },
+    )
 
 
 @never_cache
@@ -771,12 +856,19 @@ def partner_verify(request):
 
         # UUID 또는 정수형 ID(backend_designer_id) 모두 지원하는 조회 로직
         try:
+            shop_uuid_str = get_legacy_admin_id(admin=admin)
             try:
                 d_uuid = uuid.UUID(str(designer_id))
-                designer = Designer.objects.get(id=d_uuid)
-            except (ValueError, Designer.DoesNotExist):
-                designer = Designer.objects.get(backend_designer_id=designer_id)
-        except (Designer.DoesNotExist, ValueError):
+                designer = Designer.objects.filter(id=d_uuid, shop_id=shop_uuid_str).first()
+            except ValueError:
+                designer = None
+                
+            if designer is None:
+                designer = Designer.objects.filter(backend_designer_id=designer_id, shop_id=shop_uuid_str).first()
+                
+            if designer is None:
+                raise Designer.DoesNotExist
+        except Designer.DoesNotExist:
             return JsonResponse(
                 {"status": "error", "message": "선택한 디자이너 정보를 찾을 수 없습니다."},
                 status=404,
@@ -904,18 +996,31 @@ def enter_partner_dashboard(request):
     if request.method != "POST":
         return redirect("partner_index")
 
-    password = (request.POST.get("password") or "").strip()
-    if not password:
+    scope = (request.POST.get("scope") or "dashboard").strip().lower()
+    if scope not in {"dashboard", "mypage"}:
+        return JsonResponse({"status": "error", "message": "유효하지 않은 접근 범위입니다."}, status=400)
+
+    pin = (request.POST.get("pin") or request.POST.get("password") or "").strip()
+    if not pin:
         return JsonResponse({"status": "error", "message": "관리자 보안키를 입력해 주세요."}, status=400)
-    
-    # admin_pin 필드를 사용하여 보안키 검증 (비밀번호 대신 4자리 PIN 사용)
-    # 핀 번호가 설정되어 있지 않으면 기본값 '0000' 사용
-    correct_pin = admin.admin_pin or "0000"
-    if password != correct_pin:
+
+    admin_obj = _get_admin_account_for_runtime_admin(admin)
+    stored_pin = getattr(admin_obj or admin, "admin_pin", None)
+    if not _matches_admin_pin(raw_pin=pin, stored_pin=stored_pin):
         return JsonResponse({"status": "error", "message": "보안키가 일치하지 않습니다."}, status=401)
 
+    if admin_obj is not None:
+        _upgrade_plain_admin_pin_if_needed(request=request, admin_obj=admin_obj, raw_pin=pin)
+
+    # PIN 인증 성공 시 dashboard + mypage 모두 허용
+    # → 파트너센터 PIN으로 내 페이지 접근 가능 (재인증 불필요)
     allow_owner_dashboard(request=request)
-    return JsonResponse({"status": "success", "redirect": "/partner/dashboard/"})
+    allow_owner_mypage(request=request)
+    if scope == "mypage":
+        redirect_url = "/partner/mypage/"
+    else:
+        redirect_url = "/partner/dashboard/"
+    return JsonResponse({"status": "success", "redirect": redirect_url})
 
 
 @never_cache

--- a/app/management/commands/migrate_admin_pin_to_hash.py
+++ b/app/management/commands/migrate_admin_pin_to_hash.py
@@ -1,0 +1,130 @@
+"""
+management command: migrate_admin_pin_to_hash
+=============================================
+Supabase DB(shop 테이블)에 저장된 평문 admin_pin을
+Django pbkdf2_sha256 해시로 일괄 업그레이드합니다.
+
+사용법:
+    python manage.py migrate_admin_pin_to_hash            # 실제 변경
+    python manage.py migrate_admin_pin_to_hash --dry-run  # 변경 없이 대상만 출력
+
+결과:
+    - 이미 해시된 레코드: 건드리지 않음 (safe)
+    - 평문으로 저장된 레코드: make_password() 로 해시 후 저장
+    - NULL / 빈값: 기본값 "0000" 으로 해시 후 저장
+"""
+from __future__ import annotations
+
+from django.contrib.auth.hashers import identify_hasher, make_password
+from django.core.management.base import BaseCommand, CommandError
+
+from app.models_django import AdminAccount
+
+
+def _is_hashed(value: str | None) -> bool:
+    """Django hasher 식별자가 있으면 True."""
+    normalized = (value or "").strip()
+    if not normalized:
+        return False
+    try:
+        identify_hasher(normalized)
+        return True
+    except ValueError:
+        return False
+
+
+class Command(BaseCommand):
+    help = (
+        "Supabase shop 테이블의 평문 admin_pin을 pbkdf2_sha256 해시로 일괄 업그레이드합니다."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="실제 DB를 변경하지 않고 마이그레이션 대상만 출력합니다.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run: bool = options["dry_run"]
+        mode_label = "[DRY-RUN] " if dry_run else ""
+
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                f"{mode_label}admin_pin 해시 마이그레이션 시작 (shop 테이블 / Supabase)"
+            )
+        )
+
+        all_accounts = AdminAccount.objects.all().only("id", "admin_pin", "phone", "store_name", "name")
+        total = all_accounts.count()
+        self.stdout.write(f"  전체 shop 레코드: {total}건")
+
+        already_hashed = 0
+        migrated = 0
+        defaulted = 0
+        errors = 0
+
+        for account in all_accounts:
+            stored = (account.admin_pin or "").strip()
+
+            if _is_hashed(stored):
+                already_hashed += 1
+                continue
+
+            # 평문 또는 NULL/빈값
+            raw_pin = stored if stored else "0000"
+            is_default = (raw_pin == "0000")
+
+            label = (
+                f"shop_id={account.id} | "
+                f"phone={account.phone or '-'} | "
+                f"store={account.store_name or account.name or '-'}"
+            )
+
+            if dry_run:
+                action = "기본값(0000)으로 해시 예정" if is_default else f"평문 '{raw_pin}' → 해시 예정"
+                self.stdout.write(f"  [DRY] {label} | {action}")
+            else:
+                try:
+                    account.admin_pin = make_password(raw_pin)
+                    account.save(update_fields=["admin_pin"])
+                    action = "기본값(0000) 해시 완료" if is_default else f"평문 '{raw_pin}' → 해시 완료"
+                    self.stdout.write(f"  [OK]  {label} | {action}")
+                except Exception as exc:
+                    errors += 1
+                    self.stderr.write(
+                        self.style.ERROR(f"  [ERR] {label} | {exc}")
+                    )
+                    continue
+
+            migrated += 1
+            if is_default:
+                defaulted += 1
+
+        # ──────────────────────────────────────────
+        # 요약
+        # ──────────────────────────────────────────
+        self.stdout.write("")
+        self.stdout.write(self.style.MIGRATE_HEADING(f"{mode_label}마이그레이션 완료 요약"))
+        self.stdout.write(f"  전체 레코드       : {total}")
+        self.stdout.write(f"  이미 해시됨 (skip): {already_hashed}")
+        self.stdout.write(f"  마이그레이션 대상 : {migrated}")
+        self.stdout.write(f"    +- 기본값(0000)  : {defaulted}")
+        self.stdout.write(f"    +- 기존 평문 PIN : {migrated - defaulted}")
+        if errors:
+            self.stdout.write(
+                self.style.ERROR(f"  오류 발생         : {errors}")
+            )
+            raise CommandError(f"마이그레이션 중 {errors}건 오류가 발생했습니다.")
+        else:
+            self.stdout.write(self.style.SUCCESS("  오류 없이 완료되었습니다."))
+
+        if dry_run:
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING(
+                    "DRY-RUN 모드: 실제 DB는 변경되지 않았습니다. "
+                    "--dry-run 없이 다시 실행하면 적용됩니다."
+                )
+            )

--- a/app/management/commands/seed_test_accounts.py
+++ b/app/management/commands/seed_test_accounts.py
@@ -219,7 +219,7 @@ class Command(BaseCommand):
         existing.biz_number = business_number
         existing.owner_phone = "01080001000"
         existing.password = make_password("1234")
-        existing.admin_pin = "1000"
+        existing.admin_pin = make_password("1000")
         existing.name = "테스트 매장 관리자"
         existing.store_name = "MirrAI Test Shop"
         existing.role = "owner"

--- a/app/models_django.py
+++ b/app/models_django.py
@@ -1,6 +1,12 @@
+from django.contrib.auth.hashers import make_password
 from django.db import models
 import uuid
 from app.services.age_profile import build_age_profile
+
+
+def default_admin_pin_hash() -> str:
+    return make_password("0000")
+
 
 class AdminAccount(models.Model):
     id = models.UUIDField(primary_key=True, db_column='shop_id', default=uuid.uuid4)
@@ -9,7 +15,7 @@ class AdminAccount(models.Model):
     biz_number = models.CharField(max_length=20, unique=True, null=True, blank=True)
     owner_phone = models.CharField(max_length=20, null=True, blank=True)
     password = models.CharField(max_length=255, null=True, blank=True)
-    admin_pin = models.CharField(max_length=255, default="0000")
+    admin_pin = models.CharField(max_length=255, default=default_admin_pin_hash)
     created_at = models.DateTimeField(null=True, blank=True)
     updated_at = models.DateTimeField(null=True, blank=True)
     backend_admin_id = models.BigIntegerField(null=True, blank=True)

--- a/app/navigation_middleware.py
+++ b/app/navigation_middleware.py
@@ -14,7 +14,7 @@ from app.session_state import (
     get_session_designer,
     has_admin_session,
     has_designer_session,
-    revoke_owner_dashboard,
+    revoke_all_owner_scopes,
 )
 
 if TYPE_CHECKING:
@@ -73,8 +73,8 @@ class CurrentFlowNavigationMiddleware:
 
         # 나가는 페이지로 이동할 때만 인증 해제
         if view_name in exit_views:
-            if request.session.get("owner_dashboard_allowed"):
-                revoke_owner_dashboard(request=request)
+            if request.session.get("owner_dashboard_allowed") or request.session.get("owner_mypage_allowed"):
+                revoke_all_owner_scopes(request=request)
                 request.session.modified = True
 
     def _resolve_current_main_route(self, *, request: HttpRequest, include_customer: bool = True) -> str | None:
@@ -124,7 +124,7 @@ class CurrentFlowNavigationMiddleware:
 
     def _handle_designer_logout(self, request):
         clear_designer_session(request=request)
-        revoke_owner_dashboard(request=request)
+        revoke_all_owner_scopes(request=request)
         if has_admin_session(request=request):
             return self._redirect_response(request, "partner_index", ajax_route_name="partner_designer_select")
         return self._redirect_response(request, "partner_index")

--- a/app/services/model_team_bridge.py
+++ b/app/services/model_team_bridge.py
@@ -5,6 +5,7 @@ from functools import lru_cache
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Iterable
 
+from django.contrib.auth.hashers import make_password
 from django.db import DataError, connection, transaction
 from django.db.models import Count, Max, Q
 from django.utils.dateparse import parse_datetime
@@ -684,7 +685,7 @@ def create_admin_record(*, name: str, store_name: str, role: str, phone: str, bu
         biz_number=business_number,
         owner_phone=_normalize_phone(phone),
         password=password_hash,
-        admin_pin="0000",
+        admin_pin=make_password("0000"),
         created_at=created_at.isoformat(),
         updated_at=created_at.isoformat(),
         backend_admin_id=backend_admin_id,

--- a/app/session_state.py
+++ b/app/session_state.py
@@ -31,6 +31,7 @@ DESIGNER_ID_SESSION_KEY = "designer_id"
 DESIGNER_LEGACY_ID_SESSION_KEY = "designer_legacy_id"
 DESIGNER_NAME_SESSION_KEY = "designer_name"
 OWNER_DASHBOARD_ALLOWED_SESSION_KEY = "owner_dashboard_allowed"
+OWNER_MYPAGE_ALLOWED_SESSION_KEY = "owner_mypage_allowed"
 DESIGNER_DASHBOARD_ALLOWED_SESSION_KEY = "designer_dashboard_allowed"
 
 
@@ -53,6 +54,7 @@ def clear_customer_session(*, request: HttpRequest) -> None:
     request.session.pop(CUSTOMER_LEGACY_ID_SESSION_KEY, None)
     request.session.pop(CUSTOMER_NAME_SESSION_KEY, None)
     request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
+    request.session[OWNER_MYPAGE_ALLOWED_SESSION_KEY] = False
     request.session[DESIGNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
     request.session.modified = True
 
@@ -94,6 +96,7 @@ def set_admin_session(*, request: HttpRequest, admin: AdminAccount) -> None:
     request.session[ADMIN_STORE_NAME_SESSION_KEY] = admin.store_name
     request.session[ADMIN_NAME_SESSION_KEY] = admin.name
     request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
+    request.session[OWNER_MYPAGE_ALLOWED_SESSION_KEY] = False
     
     # 매장 세션은 24시간 유지
     request.session.set_expiry(24 * 60 * 60)
@@ -106,6 +109,7 @@ def clear_admin_session(*, request: HttpRequest) -> None:
     request.session.pop(ADMIN_STORE_NAME_SESSION_KEY, None)
     request.session.pop(ADMIN_NAME_SESSION_KEY, None)
     request.session.pop(OWNER_DASHBOARD_ALLOWED_SESSION_KEY, None)
+    request.session.pop(OWNER_MYPAGE_ALLOWED_SESSION_KEY, None)
     request.session.modified = True
 
 
@@ -147,6 +151,7 @@ def set_designer_session(*, request: HttpRequest, designer: Designer) -> None:
     request.session[DESIGNER_LEGACY_ID_SESSION_KEY] = get_legacy_designer_id(designer=designer)
     request.session[DESIGNER_NAME_SESSION_KEY] = designer.name
     request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
+    request.session[OWNER_MYPAGE_ALLOWED_SESSION_KEY] = False
     request.session[DESIGNER_DASHBOARD_ALLOWED_SESSION_KEY] = True
     
     # 디자이너 인증 세션은 30분 유지
@@ -159,6 +164,7 @@ def clear_designer_session(*, request: HttpRequest) -> None:
     request.session.pop(DESIGNER_LEGACY_ID_SESSION_KEY, None)
     request.session.pop(DESIGNER_NAME_SESSION_KEY, None)
     request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
+    request.session[OWNER_MYPAGE_ALLOWED_SESSION_KEY] = False
     request.session[DESIGNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
     request.session.modified = True
 
@@ -194,18 +200,54 @@ def get_session_designer(*, request: HttpRequest) -> Designer | None:
     return None
 
 
-def allow_owner_dashboard(*, request: HttpRequest) -> None:
-    request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = True
+def _set_owner_scope(*, request: HttpRequest, session_key: str, allowed: bool) -> None:
+    request.session[session_key] = allowed
     request.session.modified = True
+
+
+def allow_owner_dashboard(*, request: HttpRequest) -> None:
+    _set_owner_scope(
+        request=request,
+        session_key=OWNER_DASHBOARD_ALLOWED_SESSION_KEY,
+        allowed=True,
+    )
 
 
 def revoke_owner_dashboard(*, request: HttpRequest) -> None:
-    request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
-    request.session.modified = True
+    _set_owner_scope(
+        request=request,
+        session_key=OWNER_DASHBOARD_ALLOWED_SESSION_KEY,
+        allowed=False,
+    )
 
 
 def can_access_owner_dashboard(*, request: HttpRequest) -> bool:
     return bool(request.session.get(OWNER_DASHBOARD_ALLOWED_SESSION_KEY))
+
+
+def allow_owner_mypage(*, request: HttpRequest) -> None:
+    _set_owner_scope(
+        request=request,
+        session_key=OWNER_MYPAGE_ALLOWED_SESSION_KEY,
+        allowed=True,
+    )
+
+
+def revoke_owner_mypage(*, request: HttpRequest) -> None:
+    _set_owner_scope(
+        request=request,
+        session_key=OWNER_MYPAGE_ALLOWED_SESSION_KEY,
+        allowed=False,
+    )
+
+
+def can_access_owner_mypage(*, request: HttpRequest) -> bool:
+    return bool(request.session.get(OWNER_MYPAGE_ALLOWED_SESSION_KEY))
+
+
+def revoke_all_owner_scopes(*, request: HttpRequest) -> None:
+    revoke_owner_dashboard(request=request)
+    revoke_owner_mypage(request=request)
 
 
 def allow_designer_dashboard(*, request: HttpRequest) -> None:

--- a/app/tests/test_front_compatibility.py
+++ b/app/tests/test_front_compatibility.py
@@ -360,7 +360,7 @@ class FrontCompatibilityTests(APITestCase):
         DEBUG=True,
         STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage",
     )
-    def test_partner_dashboard_redirects_shop_only_session_back_to_partner_login(self):
+    def test_partner_dashboard_renders_pin_gate_for_shop_only_session(self):
         admin = self._create_admin(
             name="Dashboard Owner",
             store_name="MirrAI Dashboard",
@@ -378,14 +378,15 @@ class FrontCompatibilityTests(APITestCase):
 
         response = self.client.get("/partner/dashboard/")
 
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue(response["Location"].endswith("/partner/"))
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context["is_shop_owner"])
+        self.assertContains(response, 'data-admin-gate-scope="dashboard"', html=False)
 
     @override_settings(
         DEBUG=True,
         STATICFILES_STORAGE="django.contrib.staticfiles.storage.StaticFilesStorage",
     )
-    def test_partner_dashboard_enter_allows_shop_owner_session(self):
+    def test_partner_dashboard_enter_allows_dashboard_scope_only(self):
         admin = self._create_admin(
             name="Dashboard Owner",
             store_name="MirrAI Dashboard",
@@ -401,17 +402,21 @@ class FrontCompatibilityTests(APITestCase):
         )
         self._set_admin_session(admin)
 
-        enter_response = self.client.post("/partner/dashboard/enter/", {"password": "pw1234!!"})
+        enter_response = self.client.post("/partner/dashboard/enter/", {"pin": "0000", "scope": "dashboard"})
         dashboard_response = self.client.get("/partner/dashboard/")
+        session = self.client.session
 
         self.assertEqual(enter_response.status_code, 200)
         self.assertEqual(enter_response.json()["status"], "success")
         self.assertEqual(enter_response.json()["redirect"], "/partner/dashboard/")
+        self.assertTrue(session["owner_dashboard_allowed"])
+        self.assertFalse(session.get("owner_mypage_allowed", False))
         self.assertEqual(dashboard_response.status_code, 200)
+        self.assertTrue(dashboard_response.context["is_shop_owner"])
         self.assertContains(dashboard_response, 'id="showReportBtn"', html=False)
         self.assertContains(dashboard_response, "assignCustomer(")
 
-    def test_partner_dashboard_enter_requires_password_reentry(self):
+    def test_partner_dashboard_enter_requires_pin_reentry(self):
         admin = self._create_admin(
             name="Dashboard Owner",
             store_name="MirrAI Dashboard",
@@ -427,10 +432,93 @@ class FrontCompatibilityTests(APITestCase):
         )
         self._set_admin_session(admin)
 
-        response = self.client.post("/partner/dashboard/enter/", {"password": "wrong"})
+        response = self.client.post("/partner/dashboard/enter/", {"pin": "1111", "scope": "dashboard"})
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(response.json()["message"], "비밀번호를 다시 확인해 주세요.")
+        self.assertEqual(response.json()["message"], "보안키가 일치하지 않습니다.")
+
+    def test_partner_dashboard_enter_allows_mypage_scope_only(self):
+        admin = self._create_admin(
+            name="Dashboard Owner",
+            store_name="MirrAI Dashboard",
+            role="owner",
+            phone="01055556663",
+            business_number=build_valid_business_number("920456780"),
+            password_hash=make_password("pw1234!!"),
+            consent_snapshot={
+                "agree_terms": True,
+                "agree_privacy": True,
+                "agree_third_party_sharing": True,
+            },
+        )
+        self._set_admin_session(admin)
+
+        enter_response = self.client.post("/partner/dashboard/enter/", {"pin": "0000", "scope": "mypage"})
+        mypage_response = self.client.get("/partner/mypage/")
+        session = self.client.session
+
+        self.assertEqual(enter_response.status_code, 200)
+        self.assertEqual(enter_response.json()["status"], "success")
+        self.assertEqual(enter_response.json()["redirect"], "/partner/mypage/")
+        self.assertTrue(session["owner_mypage_allowed"])
+        self.assertFalse(session.get("owner_dashboard_allowed", False))
+        self.assertEqual(mypage_response.status_code, 200)
+        self.assertTrue(mypage_response.context["is_mypage_owner"])
+
+    def test_partner_dashboard_enter_upgrades_plaintext_admin_pin(self):
+        admin = self._create_admin(
+            name="Dashboard Owner",
+            store_name="MirrAI Dashboard",
+            role="owner",
+            phone="01055556662",
+            business_number=build_valid_business_number("919456780"),
+            password_hash=make_password("pw1234!!"),
+            consent_snapshot={
+                "agree_terms": True,
+                "agree_privacy": True,
+                "agree_third_party_sharing": True,
+            },
+        )
+        AdminAccount.objects.filter(backend_admin_id=admin.id).update(admin_pin="1234")
+        self._set_admin_session(admin)
+
+        response = self.client.post("/partner/dashboard/enter/", {"pin": "1234", "scope": "dashboard"})
+        persisted_admin = AdminAccount.objects.get(backend_admin_id=admin.id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotEqual(persisted_admin.admin_pin, "1234")
+        self.assertTrue(check_password("1234", persisted_admin.admin_pin))
+
+    def test_partner_mypage_change_pin_hashes_new_value(self):
+        admin = self._create_admin(
+            name="Dashboard Owner",
+            store_name="MirrAI Dashboard",
+            role="owner",
+            phone="01055556661",
+            business_number=build_valid_business_number("918456780"),
+            password_hash=make_password("pw1234!!"),
+            consent_snapshot={
+                "agree_terms": True,
+                "agree_privacy": True,
+                "agree_third_party_sharing": True,
+            },
+        )
+        self._set_admin_session(admin)
+
+        response = self.client.post(
+            "/partner/mypage/",
+            {
+                "action": "change_pin",
+                "current_pin": "0000",
+                "admin_pin": "2468",
+            },
+        )
+        persisted_admin = AdminAccount.objects.get(backend_admin_id=admin.id)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "success")
+        self.assertTrue(check_password("2468", persisted_admin.admin_pin))
+        self.assertFalse(response.json()["is_default_admin_pin"])
 
     def test_partner_dashboard_redirects_designer_to_staff_dashboard(self):
         admin = self._create_admin(

--- a/app/tests/test_legacy_model_sync.py
+++ b/app/tests/test_legacy_model_sync.py
@@ -2,6 +2,7 @@
 
 import io
 
+from django.contrib.auth.hashers import check_password
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.management import call_command
 from django.db import connection
@@ -525,7 +526,7 @@ class LegacyModelSyncTests(TransactionTestCase):
         self.assertEqual(shop_row[1], "MirrAI Test Shop")
         self.assertEqual(shop_row[2], "1012345672")
         self.assertEqual(shop_row[3], "01080001000")
-        self.assertEqual(shop_row[4], "1000")
+        self.assertTrue(check_password("1000", shop_row[4]))
 
         client_row = self._fetch_one(
             "SELECT client_name, phone, gender FROM client WHERE phone = %s",

--- a/app/urls_front.py
+++ b/app/urls_front.py
@@ -34,7 +34,7 @@ from app.front_views import (
     privacy_policy_page,
     terms_page,
 )
-from app.dashboard_gate_views import gated_partner_dashboard, gated_partner_staff_dashboard
+from app.dashboard_gate_views import gated_partner_dashboard, gated_partner_mypage, gated_partner_staff_dashboard
 
 
 urlpatterns = [
@@ -68,7 +68,7 @@ urlpatterns = [
     path("partner/select-designer/", partner_select_designer, name="partner_select_designer"),
     path("partner/dashboard/enter/", enter_partner_dashboard, name="partner_dashboard_enter"),
     path("partner/dashboard/", gated_partner_dashboard, name="partner_dashboard"),
-    path("partner/mypage/", admin_mypage_page, name="partner_mypage"),
+    path("partner/mypage/", gated_partner_mypage, name="partner_mypage"),
     path("partner/staff/", gated_partner_staff_dashboard, name="partner_staff_dashboard"),
     path(
         "partner/customer-detail/<int:pk>/",

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -171,7 +171,7 @@
         <div>
           {% if is_designer_session %}
             <h2 class="section-title compact" style="margin-bottom: 4px;">{{ designer.name }} 디자이너 대시보드</h2>
-            <p class="section-copy">{{ admin.store_name }} 매장 고객 현황</p>
+            <p class="section-copy">{{ designer.name }} 디자이너 담당 고객 현황</p>
           {% else %}
             <h2 class="section-title compact" style="margin-bottom: 4px;">{{ admin.store_name }} 매장 대시보드</h2>
             <p class="section-copy">고객 현황과 디자이너 배정 상태를 한눈에 확인할 수 있습니다.</p>
@@ -225,10 +225,16 @@
       <div id="reportViewContainer" style="display: none;">
         <div style="display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 20px;">
           <div class="report-tabs">
-            <button type="button" class="report-tab-btn active" data-report-type="styleTop10">매장 스타일 TOP10</button>
+            {% if is_designer_session %}
+              <button type="button" class="report-tab-btn active" data-report-type="styleTop10">상담 스타일 TOP10</button>
+            {% else %}
+              <button type="button" class="report-tab-btn active" data-report-type="styleTop10">매장 스타일 TOP10</button>
+            {% endif %}
             <button type="button" class="report-tab-btn" data-report-type="dailyVisitors">일별 방문자</button>
             <button type="button" class="report-tab-btn" data-report-type="ageVisitors">연령별 방문자</button>
-            <button type="button" class="report-tab-btn" data-report-type="designerCustomers">디자이너별 고객수</button>
+            {% if not is_designer_session %}
+              <button type="button" class="report-tab-btn" data-report-type="designerCustomers">디자이너별 고객수</button>
+            {% endif %}
           </div>
           <div style="display: flex; gap: 8px; align-items: center; margin-bottom: 22px;">
             <select id="reportPeriodSelect" class="form-control" style="width: auto; height: 32px; font-size: 13px; padding: 0 12px 0 10px; border-radius: 999px; border: 1.5px solid var(--line); background: #fff; cursor: pointer; color: var(--bg-dark); font-weight: 600; outline: none; display: none;">
@@ -335,11 +341,8 @@
         if (data.status === 'success') {
           updateStatus("로그인 성공!", "success");
           const urlParams = new URLSearchParams(window.location.search);
-          const defaultNextUrl = (data.redirect && data.redirect !== '/partner/login/') ? data.redirect : "/partner/dashboard/";
+          const defaultNextUrl = (data.redirect && data.redirect !== '/partner/login/') ? data.redirect : "/";
           const nextUrl = urlParams.get('next') || defaultNextUrl;
-          if (nextUrl.startsWith('/partner/dashboard')) {
-            void prefetchPartnerDashboardData();
-          }
           await nextFrame();
           window.location.replace(nextUrl);
         } else { handleFail(data.message); }

--- a/templates/admin/mypage.html
+++ b/templates/admin/mypage.html
@@ -5,53 +5,160 @@
 
 {% block extra_head %}
 <style>
-  /* Admin PIN Change Modal Styles */
-  .pin-change-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.85);
-    backdrop-filter: blur(8px);
+  .mypage-shell {
+    display: block;
+  }
+
+  .mypage-panel {
+    max-width: 640px;
+    margin: 0 auto;
+    padding: 48px !important;
+    border-radius: 24px !important;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;
+  }
+
+  .mypage-section + .mypage-section {
+    margin-top: 40px;
+  }
+
+  .mypage-section-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 24px;
+    padding-bottom: 12px;
+    border-bottom: 1.5px solid var(--line);
+  }
+
+  .mypage-section-head h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+
+  .mypage-info-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .mypage-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  .mypage-label {
+    font-size: 14px;
+    color: var(--text-secondary);
+  }
+
+  .mypage-value {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-align: right;
+  }
+
+  .mypage-security-card {
+    padding: 24px;
+    background: var(--bg-light);
+    border-radius: 16px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .mypage-security-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 12px;
+    background: #fff;
     display: flex;
     align-items: center;
     justify-content: center;
+    font-size: 24px;
+    flex: 0 0 auto;
+  }
+
+  .mypage-security-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .mypage-security-copy {
+    margin: 4px 0 0;
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+  }
+
+  .pin-change-overlay,
+  #warningOverlay {
+    position: fixed;
+    inset: 0;
+    padding: 24px;
+    box-sizing: border-box;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.82);
+    backdrop-filter: blur(8px);
+  }
+
+  .pin-change-overlay {
     z-index: 2000;
-    opacity: 0;
-    visibility: hidden;
-    transition: all 0.3s ease;
   }
-  .pin-change-overlay.is-active {
-    opacity: 1;
-    visibility: visible;
+
+  #warningOverlay {
+    z-index: 2100;
   }
-  .pin-change-container {
-    width: 320px;
+
+  .pin-change-overlay.is-active,
+  #warningOverlay.is-active {
+    display: flex;
+  }
+
+  .pin-change-container,
+  .warning-container {
+    width: min(100%, 340px);
     background: var(--bg-dark);
     border: 1px solid var(--line);
     border-radius: 24px;
-    padding: 32px;
-    text-align: center;
     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
   }
+
+  .pin-change-container {
+    padding: 32px;
+    text-align: center;
+  }
+
   .pin-change-title {
+    margin: 0 0 8px;
     font-size: 18px;
     font-weight: 700;
     color: #fff;
-    margin-bottom: 8px;
   }
+
   .pin-change-subtitle {
+    margin: 0 0 24px;
     font-size: 13px;
-    color: rgba(255, 255, 255, 0.5);
-    margin-bottom: 24px;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.55);
   }
+
   .pin-change-display {
     display: flex;
     justify-content: center;
     gap: 12px;
     margin-bottom: 32px;
   }
+
   .pin-change-dot {
     width: 16px;
     height: 16px;
@@ -59,15 +166,18 @@
     background: rgba(255, 255, 255, 0.1);
     transition: all 0.2s ease;
   }
+
   .pin-change-dot.is-filled {
     background: var(--accent-neon);
     box-shadow: 0 0 10px var(--accent-neon);
   }
+
   .pin-change-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 12px;
   }
+
   .pin-change-btn {
     aspect-ratio: 1;
     border-radius: 50%;
@@ -82,57 +192,92 @@
     justify-content: center;
     transition: all 0.15s ease;
   }
+
   .pin-change-btn:active {
     background: rgba(255, 255, 255, 0.2);
     transform: scale(0.92);
   }
+
   .pin-change-btn.btn-empty {
     background: transparent;
     border: none;
     cursor: default;
   }
+
   .pin-change-btn.btn-back {
     font-size: 14px;
     color: var(--status-red);
   }
+
   .pin-change-close {
     margin-top: 24px;
     font-size: 14px;
-    color: rgba(255, 255, 255, 0.4);
-    background: none;
-    border: none;
-    cursor: pointer;
-    text-decoration: underline;
-  }
-    color: rgba(255, 255, 255, 0.4);
+    color: rgba(255, 255, 255, 0.45);
     background: none;
     border: none;
     cursor: pointer;
     text-decoration: underline;
   }
 
-  /* Warning Popup Styles */
-  #warningOverlay {
-    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-    background: rgba(0, 0, 0, 0.85); backdrop-filter: blur(8px);
-    display: flex; align-items: center; justify-content: center;
-    z-index: 2100; opacity: 0; visibility: hidden; transition: all 0.3s ease;
-  }
-  #warningOverlay.is-active { opacity: 1; visibility: visible; }
   .warning-container {
-    width: 340px; background: var(--bg-dark); border: 1px solid var(--line);
-    border-radius: 24px; padding: 40px 32px; text-align: center;
-    box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+    padding: 40px 32px;
+    text-align: center;
   }
-  .warning-icon { font-size: 40px; margin-bottom: 20px; display: block; }
-  .warning-title { font-size: 18px; font-weight: 700; color: #fff; margin-bottom: 12px; line-height: 1.4; }
-  .warning-text { font-size: 14px; color: rgba(255, 255, 255, 0.6); margin-bottom: 32px; line-height: 1.6; }
+
+  .warning-icon {
+    font-size: 40px;
+    margin-bottom: 20px;
+    display: block;
+  }
+
+  .warning-title {
+    margin: 0 0 12px;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.4;
+    color: #fff;
+  }
+
+  .warning-text {
+    margin: 0 0 32px;
+    font-size: 14px;
+    line-height: 1.7;
+    color: rgba(255, 255, 255, 0.68);
+  }
+
   .warning-btn {
-    width: 100%; height: 52px; border-radius: 14px; border: none;
-    background: var(--accent-neon); color: var(--bg-dark);
-    font-size: 16px; font-weight: 700; cursor: pointer; transition: all 0.2s;
+    width: 100%;
+    height: 52px;
+    border-radius: 14px;
+    border: none;
+    background: var(--accent-neon);
+    color: var(--bg-dark);
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.2s ease;
   }
-  .warning-btn:active { transform: scale(0.96); }
+
+  .warning-btn:active {
+    transform: scale(0.97);
+  }
+
+  @media (max-width: 768px) {
+    .mypage-panel {
+      padding: 32px 24px !important;
+    }
+
+    .mypage-section-head,
+    .mypage-row,
+    .mypage-security-card {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .mypage-value {
+      text-align: left;
+    }
+  }
 </style>
 {% endblock %}
 
@@ -144,49 +289,49 @@
 {% endblock %}
 
 {% block content %}
-<div class="customer-layout" style="display: block;">
-  <div class="panel" style="max-width: 600px; margin: 0 auto; padding: 48px !important; border-radius: 24px !important; box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04) !important;">
-
-    <div style="margin-bottom: 40px;">
-      <h3 style="font-size: 18px; font-weight: 700; margin-bottom: 24px; color: var(--text-primary); border-bottom: 1.5px solid var(--line); padding-bottom: 12px;">기본 정보</h3>
-      <div style="display: flex; flex-direction: column; gap: 16px;">
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <span style="color: var(--text-secondary); font-size: 14px;">매장명</span>
-          <span style="color: var(--text-primary); font-weight: 600;">{{ active_shop.store_name }}</span>
+<div class="customer-layout mypage-shell">
+  <div class="panel mypage-panel">
+    <section class="mypage-section">
+      <div class="mypage-section-head">
+        <h3>기본 정보</h3>
+      </div>
+      <div class="mypage-info-list">
+        <div class="mypage-row">
+          <span class="mypage-label">매장명</span>
+          <span class="mypage-value">{{ active_shop.store_name }}</span>
         </div>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <span style="color: var(--text-secondary); font-size: 14px;">관리자명</span>
-          <span style="color: var(--text-primary); font-weight: 600;">{{ active_shop.name }}</span>
+        <div class="mypage-row">
+          <span class="mypage-label">관리자명</span>
+          <span class="mypage-value">{{ active_shop.name }}</span>
         </div>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <span style="color: var(--text-secondary); font-size: 14px;">연락처</span>
-          <span style="color: var(--text-primary); font-weight: 600;">{{ active_shop.phone }}</span>
+        <div class="mypage-row">
+          <span class="mypage-label">연락처</span>
+          <span class="mypage-value">{{ active_shop.phone }}</span>
         </div>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <span style="color: var(--text-secondary); font-size: 14px;">사업자번호</span>
-          <span style="color: var(--text-primary); font-weight: 600;">{{ active_shop.business_number }}</span>
+        <div class="mypage-row">
+          <span class="mypage-label">사업자번호</span>
+          <span class="mypage-value">{{ active_shop.business_number }}</span>
         </div>
       </div>
-    </div>
+    </section>
 
-    <div>
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; border-bottom: 1.5px solid var(--line); padding-bottom: 12px;">
-        <h3 style="font-size: 18px; font-weight: 700; color: var(--text-primary); margin: 0;">보안 설정</h3>
-        <button id="openKeypadBtn" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; font-weight: 600;">보안키 변경</button>
+    <section class="mypage-section">
+      <div class="mypage-section-head">
+        <h3>보안 설정</h3>
+        <button id="openKeypadBtn" type="button" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; font-weight: 600;">보안키 변경</button>
       </div>
 
-      <div style="padding: 24px; background: var(--bg-light); border-radius: 16px; display: flex; align-items: center; gap: 16px;">
-        <div style="width: 48px; height: 48px; background: #fff; border-radius: 12px; display: flex; align-items: center; justify-content: center; font-size: 24px;">🔑</div>
+      <div class="mypage-security-card">
+        <div class="mypage-security-icon">🔑</div>
         <div>
-          <p style="margin: 0; font-size: 15px; font-weight: 600; color: var(--text-primary);">관리자 보안키 (PIN)</p>
-          <p style="margin: 4px 0 0 0; font-size: 13px; color: var(--text-secondary);">매장 내 민감한 정보 접근 시 사용되는 4자리 보안키입니다.</p>
+          <p class="mypage-security-title">관리자 보안키 (PIN)</p>
+          <p class="mypage-security-copy">매장 내 민감한 정보 접근 시 사용되는 4자리 보안키입니다.</p>
         </div>
       </div>
-    </div>
+    </section>
   </div>
 </div>
 
-<!-- PIN Change Modal -->
 <div id="pinChangeOverlay" class="pin-change-overlay">
   <div class="pin-change-container">
     <div id="pinChangeStepTitle" class="pin-change-title">보안키 확인</div>
@@ -200,31 +345,30 @@
     </div>
 
     <div class="pin-change-grid">
-      <button class="pin-change-btn" data-val="1">1</button>
-      <button class="pin-change-btn" data-val="2">2</button>
-      <button class="pin-change-btn" data-val="3">3</button>
-      <button class="pin-change-btn" data-val="4">4</button>
-      <button class="pin-change-btn" data-val="5">5</button>
-      <button class="pin-change-btn" data-val="6">6</button>
-      <button class="pin-change-btn" data-val="7">7</button>
-      <button class="pin-change-btn" data-val="8">8</button>
-      <button class="pin-change-btn" data-val="9">9</button>
+      <button type="button" class="pin-change-btn" data-val="1">1</button>
+      <button type="button" class="pin-change-btn" data-val="2">2</button>
+      <button type="button" class="pin-change-btn" data-val="3">3</button>
+      <button type="button" class="pin-change-btn" data-val="4">4</button>
+      <button type="button" class="pin-change-btn" data-val="5">5</button>
+      <button type="button" class="pin-change-btn" data-val="6">6</button>
+      <button type="button" class="pin-change-btn" data-val="7">7</button>
+      <button type="button" class="pin-change-btn" data-val="8">8</button>
+      <button type="button" class="pin-change-btn" data-val="9">9</button>
       <div class="pin-change-btn btn-empty"></div>
-      <button class="pin-change-btn" data-val="0">0</button>
-      <button class="pin-change-btn btn-back" id="pinChangeBack">삭제</button>
+      <button type="button" class="pin-change-btn" data-val="0">0</button>
+      <button type="button" class="pin-change-btn btn-back" id="pinChangeBack">삭제</button>
     </div>
 
-    <button id="closePinChangeBtn" class="pin-change-close">닫기</button>
+    <button id="closePinChangeBtn" type="button" class="pin-change-close">취소</button>
   </div>
 </div>
 
-<!-- Initial PIN Warning Popup -->
 <div id="warningOverlay">
   <div class="warning-container">
     <span class="warning-icon">⚠️</span>
     <div class="warning-title">보안 위험 알림</div>
-    <p class="warning-text">현재 보안키가 0000으로 셋팅 되어 있습니다.<br>보안이 취약하오니 보안키를 변경해주세요!</p>
-    <button id="goToChangePinBtn" class="warning-btn">보안키 변경하기</button>
+    <p class="warning-text">현재 보안키가 0000으로 설정되어 있습니다.<br>보안이 취약하오니 보안키를 변경해 주세요.</p>
+    <button id="goToChangePinBtn" type="button" class="warning-btn">보안키 변경하기</button>
   </div>
 </div>
 {% endblock %}
@@ -234,8 +378,8 @@
   (function() {
     'use strict';
 
-    const currentPin = "{{ active_shop.admin_pin|default:'' }}";
-    console.log("[MyPage] Loaded admin PIN:", currentPin);
+    const isMypageVerified = {% if is_mypage_owner %}true{% else %}false{% endif %};
+    let isDefaultAdminPin = {% if is_default_admin_pin %}true{% else %}false{% endif %};
     const overlay = document.getElementById('pinChangeOverlay');
     const warningOverlay = document.getElementById('warningOverlay');
     const goToChangePinBtn = document.getElementById('goToChangePinBtn');
@@ -244,150 +388,196 @@
     const dots = document.querySelectorAll('.pin-change-dot');
     const titleEl = document.getElementById('pinChangeStepTitle');
     const subEl = document.getElementById('pinChangeStepSub');
-    const statusAlert = document.getElementById('statusAlert');
+    const keypadButtons = document.querySelectorAll('.pin-change-btn[data-val]');
+    const backBtn = document.getElementById('pinChangeBack');
 
-    let state = 'VERIFY_CURRENT'; // VERIFY_CURRENT -> ENTER_NEW -> CONFIRM_NEW
+    let state = 'VERIFY_CURRENT';
     let inputBuffer = '';
+    let verifiedCurrentPin = '';
     let newPinBuffer = '';
 
-    // 초기 방문 체크 (0000인 경우 커스텀 팝업 노출)
     window.addEventListener('load', () => {
-      if (currentPin === '0000') {
-        if (warningOverlay) warningOverlay.classList.add('is-active');
+      if (isMypageVerified && isDefaultAdminPin && warningOverlay) {
+        warningOverlay.classList.add('is-active');
       }
     });
 
-    if (goToChangePinBtn) {
-      goToChangePinBtn.onclick = () => {
-        if (warningOverlay) warningOverlay.classList.remove('is-active');
-        openKeypad();
-      };
-    }
-
     function openKeypad() {
       resetKeypad();
+      if (warningOverlay) {
+        warningOverlay.classList.remove('is-active');
+      }
       overlay.classList.add('is-active');
     }
 
     function closeKeypad() {
       overlay.classList.remove('is-active');
+      if (isMypageVerified && isDefaultAdminPin && warningOverlay) {
+        warningOverlay.classList.add('is-active');
+      }
     }
 
     function resetKeypad() {
       state = 'VERIFY_CURRENT';
       inputBuffer = '';
+      verifiedCurrentPin = '';
       newPinBuffer = '';
       updateUI();
     }
 
     function updateUI() {
-      // Update Title & Subtitle based on state
       if (state === 'VERIFY_CURRENT') {
         titleEl.textContent = '현재 보안키 확인';
-        subEl.textContent = '현재 사용 중인 보안키 4자리를 입력하세요.';
+        subEl.textContent = '현재 사용 중인 보안키 4자리를 입력해 주세요.';
       } else if (state === 'ENTER_NEW') {
         titleEl.textContent = '새 보안키 설정';
-        subEl.textContent = '변경할 새로운 보안키 4자리를 입력하세요.';
+        subEl.textContent = '변경할 새로운 보안키 4자리를 입력해 주세요.';
       } else if (state === 'CONFIRM_NEW') {
         titleEl.textContent = '보안키 재확인';
-        subEl.textContent = '확인을 위해 새 보안키를 다시 입력하세요.';
+        subEl.textContent = '확인을 위해 새 보안키를 다시 입력해 주세요.';
       }
 
-      // Update dots
       dots.forEach((dot, idx) => {
         dot.classList.toggle('is-filled', idx < inputBuffer.length);
       });
     }
 
-    function handleInput(val) {
-      if (inputBuffer.length >= 4) return;
-      inputBuffer += val;
+    function handleInput(value) {
+      if (inputBuffer.length >= 4) {
+        return;
+      }
+
+      inputBuffer += value;
       updateUI();
 
       if (inputBuffer.length === 4) {
-        setTimeout(processStep, 300);
+        setTimeout(processStep, 250);
       }
     }
 
     function handleBack() {
-      if (inputBuffer.length > 0) {
-        inputBuffer = inputBuffer.slice(0, -1);
-        updateUI();
+      if (!inputBuffer.length) {
+        return;
       }
+
+      inputBuffer = inputBuffer.slice(0, -1);
+      updateUI();
+    }
+
+    async function verifyCurrentPin(pin) {
+      const formData = new URLSearchParams();
+      formData.append('action', 'verify_current_pin');
+      formData.append('current_pin', pin);
+
+      const response = await fetch(window.location.pathname, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'X-CSRFToken': '{{ csrf_token }}',
+        },
+        body: formData.toString(),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        alert(data.message || '현재 보안키가 일치하지 않습니다.');
+        return false;
+      }
+      return true;
     }
 
     async function processStep() {
       if (state === 'VERIFY_CURRENT') {
-        if (inputBuffer === currentPin) {
+        const verified = await verifyCurrentPin(inputBuffer);
+        if (verified) {
+          verifiedCurrentPin = inputBuffer;
           state = 'ENTER_NEW';
           inputBuffer = '';
           updateUI();
-        } else {
-          alert('현재 보안키가 일치하지 않습니다.');
-          inputBuffer = '';
-          updateUI();
+          return;
         }
-      } else if (state === 'ENTER_NEW') {
+
+        inputBuffer = '';
+        updateUI();
+        return;
+      }
+
+      if (state === 'ENTER_NEW') {
         newPinBuffer = inputBuffer;
         state = 'CONFIRM_NEW';
         inputBuffer = '';
         updateUI();
-      } else if (state === 'CONFIRM_NEW') {
-        if (inputBuffer === newPinBuffer) {
-          await finalizeChange(newPinBuffer);
-        } else {
-          alert('새 보안키가 일치하지 않습니다. 처음부터 다시 시도해 주세요.');
-          resetKeypad();
-        }
+        return;
       }
+
+      if (inputBuffer !== newPinBuffer) {
+        alert('새 보안키가 일치하지 않습니다. 처음부터 다시 시도해 주세요.');
+        resetKeypad();
+        return;
+      }
+
+      await finalizeChange(newPinBuffer);
     }
 
     async function finalizeChange(pin) {
       try {
         const formData = new URLSearchParams();
+        formData.append('action', 'change_pin');
+        formData.append('current_pin', verifiedCurrentPin);
         formData.append('admin_pin', pin);
 
         const response = await fetch(window.location.pathname, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'X-CSRFToken': '{{ csrf_token }}'
+            'X-CSRFToken': '{{ csrf_token }}',
           },
-          body: formData.toString()
+          body: formData.toString(),
         });
 
         const data = await response.json();
 
-        if (response.ok) {
-          alert(data.message || '보안키가 성공적으로 변경되었습니다.');
-          closeKeypad();
-          // 보안키 변경 후 최신 상태 유지를 위해 필요한 경우에만 새로고침 (선택 사항)
-          // window.location.reload();
-        } else {
-          // 서버에서 전달한 에러 메시지 표시
-          const errorMsg = data.message || '현재 사용 중인 보안키와 동일합니다. 다른 번호를 입력해 주세요.';
-          alert(errorMsg);
-
-          // 모달을 닫지 않고 새 보안키 입력 단계로 초기화
+        if (!response.ok) {
+          alert(data.message || '보안키 변경 중 오류가 발생했습니다.');
           state = 'ENTER_NEW';
           inputBuffer = '';
           updateUI();
+          return;
         }
-      } catch (err) {
-        console.error("PIN change error:", err);
+
+        verifiedCurrentPin = pin;
+        isDefaultAdminPin = Boolean(data.is_default_admin_pin);
+        closeKeypad();
+        if (warningOverlay) {
+          warningOverlay.classList.remove('is-active');
+        }
+        alert(data.message || '보안키가 성공적으로 변경되었습니다.');
+      } catch (error) {
+        console.error('PIN change error:', error);
         alert('서버 처리 중 오류가 발생했습니다.');
         resetKeypad();
       }
     }
 
-    // Events
-    openBtn.addEventListener('click', openKeypad);
-    closeBtn.addEventListener('click', closeKeypad);
-    document.querySelectorAll('.pin-change-btn[data-val]').forEach(btn => {
-      btn.addEventListener('click', () => handleInput(btn.dataset.val));
-    });
-    document.getElementById('pinChangeBack').addEventListener('click', handleBack);
+    if (goToChangePinBtn) {
+      goToChangePinBtn.addEventListener('click', openKeypad);
+    }
 
+    if (openBtn) {
+      openBtn.addEventListener('click', openKeypad);
+    }
+
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closeKeypad);
+    }
+
+    keypadButtons.forEach((button) => {
+      button.addEventListener('click', () => handleInput(button.dataset.val));
+    });
+
+    if (backBtn) {
+      backBtn.addEventListener('click', handleBack);
+    }
   })();
 </script>
 {% endblock %}

--- a/templates/layouts/base_site.html
+++ b/templates/layouts/base_site.html
@@ -98,14 +98,14 @@
               {% if request.session.admin_id and not request.session.designer_id %}
                 {# 오직 매장 로그인 상태에서만: 페이지별 노출 조건 분기 #}
                 {% if request.resolver_match.url_name == 'index' or request.resolver_match.url_name == 'partner_designer_select' %}
-                  <a href="{% url 'partner_mypage' %}" class="nav-link" data-admin-gate="true">내 페이지</a>
-                  <a href="{% url 'partner_dashboard' %}" class="nav-link" data-admin-gate="true">파트너 센터</a>
+                  <a href="{% url 'partner_mypage' %}" class="nav-link" data-admin-gate="true" data-admin-gate-scope="mypage">내 페이지</a>
+                  <a href="{% url 'partner_dashboard' %}" class="nav-link" data-admin-gate="true" data-admin-gate-scope="dashboard">파트너 센터</a>
                 {% elif request.resolver_match.url_name == 'partner_mypage' %}
-                  <a href="{% url 'partner_dashboard' %}" class="nav-link" data-admin-gate="true">파트너 센터</a>
+                  <a href="{% url 'partner_dashboard' %}" class="nav-link" data-admin-gate="true" data-admin-gate-scope="dashboard">파트너 센터</a>
                 {% elif request.resolver_match.url_name == 'partner_dashboard' %}
-                  <a href="{% url 'partner_mypage' %}" class="nav-link" data-admin-gate="true">내 페이지</a>
+                  <a href="{% url 'partner_mypage' %}" class="nav-link" data-admin-gate="true" data-admin-gate-scope="mypage">내 페이지</a>
                 {% else %}
-                  <a href="{% url 'partner_dashboard' %}" class="nav-link" data-admin-gate="true">파트너 센터</a>
+                  <a href="{% url 'partner_dashboard' %}" class="nav-link" data-admin-gate="true" data-admin-gate-scope="dashboard">파트너 센터</a>
                 {% endif %}
               {% elif not request.session.admin_id and not request.session.designer_id %}
                 {# 아무도 로그인하지 않은 경우에만 로그인 유도 #}
@@ -270,21 +270,21 @@
         </div>
 
         <div class="keypad-grid">
-          <button class="keypad-btn" onclick="appendPin('1')">1</button>
-          <button class="keypad-btn" onclick="appendPin('2')">2</button>
-          <button class="keypad-btn" onclick="appendPin('3')">3</button>
-          <button class="keypad-btn" onclick="appendPin('4')">4</button>
-          <button class="keypad-btn" onclick="appendPin('5')">5</button>
-          <button class="keypad-btn" onclick="appendPin('6')">6</button>
-          <button class="keypad-btn" onclick="appendPin('7')">7</button>
-          <button class="keypad-btn" onclick="appendPin('8')">8</button>
-          <button class="keypad-btn" onclick="appendPin('9')">9</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('1')">1</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('2')">2</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('3')">3</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('4')">4</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('5')">5</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('6')">6</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('7')">7</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('8')">8</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('9')">9</button>
           <div class="keypad-btn btn-empty"></div>
-          <button class="keypad-btn" onclick="appendPin('0')">0</button>
-          <button class="keypad-btn btn-back" onclick="backspacePin()">삭제</button>
+          <button class="keypad-btn" onclick="adminGateAppendPin('0')">0</button>
+          <button class="keypad-btn btn-back" onclick="adminGateBackspacePin()">삭제</button>
         </div>
 
-        <button onclick="closeAdminPinModal()" class="keypad-close">취소 (닫기)</button>
+        <button onclick="adminGateCloseModal()" class="keypad-close">취소 (닫기)</button>
       </div>
     </div>
 
@@ -294,40 +294,83 @@
       (function() {
         let currentPin = '';
         let pinTargetType = ''; 
-        let pinTargetId = '';   
+        let pinTargetId = '';
+        let pinTargetScope = 'dashboard';
         const pinModal = document.getElementById('adminPinModal');
         const pinDots = document.querySelectorAll('#adminPinModal .keypad-dot');
         const pinSubtext = document.getElementById('pinModalSubtext');
 
-        window.openAdminPinModal = function(type, id = '', message = '') {
+        const submitAdminGatePin = async function() {
+          if (!currentPin || currentPin.length < 4) return;
+
+          const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value || '{{ csrf_token }}';
+
+          try {
+            const response = await fetch('/partner/dashboard/enter/', {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'X-CSRFToken': csrfToken
+              },
+              body: `pin=${encodeURIComponent(currentPin)}&scope=${encodeURIComponent(pinTargetScope)}`
+            });
+            const data = await response.json();
+            if (data.status === 'success') {
+              window.adminGateCloseModal();
+              if (pinTargetType === 'header' || pinTargetType === 'current-view') {
+                if (window.location.pathname + window.location.search === pinTargetId) {
+                  window.location.reload();
+                } else {
+                  window.location.href = pinTargetId;
+                }
+              } else if (pinTargetType === 'dashboard') {
+                window.location.href = data.redirect || '/partner/dashboard/';
+              } else if (pinTargetType === 'detail') {
+                window.location.href = `/partner/customer-detail/${pinTargetId}/`;
+              } else {
+                window.location.reload();
+              }
+            } else {
+              alert(data.message || '보안키가 일치하지 않습니다.');
+              window.adminGateClearPin();
+            }
+          } catch (error) {
+            console.error('PIN submit error:', error);
+            alert('인증 처리 중 오류가 발생했습니다.');
+            window.adminGateClearPin();
+          }
+        };
+
+        window.openAdminPinModal = function(type, id = '', message = '', scope = 'dashboard') {
           currentPin = '';
           pinTargetType = type;
           pinTargetId = id;
+          pinTargetScope = scope;
           if (pinSubtext && message) pinSubtext.textContent = message;
           updatePinDots();
           if (pinModal) pinModal.classList.add('active');
         };
 
-        window.closeAdminPinModal = function() {
+        window.adminGateCloseModal = function() {
           if (pinModal) pinModal.classList.remove('active');
         };
 
-        window.appendPin = function(num) {
+        window.adminGateAppendPin = function(num) {
           if (currentPin.length < 4) {
             currentPin += num;
             updatePinDots();
             if (currentPin.length === 4) {
-              setTimeout(submitPin, 300);
+              setTimeout(submitAdminGatePin, 300);
             }
           }
         };
 
-        window.clearPin = function() {
+        window.adminGateClearPin = function() {
           currentPin = '';
           updatePinDots();
         };
 
-        window.backspacePin = function() {
+        window.adminGateBackspacePin = function() {
           if (currentPin.length > 0) {
             currentPin = currentPin.slice(0, -1);
             updatePinDots();
@@ -341,72 +384,45 @@
           });
         }
 
-        window.submitPin = async function() {
-          if (!currentPin || currentPin.length < 4) return;
-          
-          const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]')?.value || '{{ csrf_token }}';
-          
-          try {
-            const response = await fetch('/partner/dashboard/enter/', {
-              method: 'POST',
-              headers: { 
-                'Content-Type': 'application/x-www-form-urlencoded', 
-                'X-CSRFToken': csrfToken 
-              },
-              body: `password=${encodeURIComponent(currentPin)}`
-            });
-            const data = await response.json();
-            if (data.status === 'success') {
-              if (pinTargetType === 'header') {
-                window.location.href = pinTargetId;
-              } else if (pinTargetType === 'dashboard') {
-                window.location.href = data.redirect || '/partner/dashboard/';
-              } else if (pinTargetType === 'detail') {
-                window.location.href = `/partner/customer-detail/${pinTargetId}/`;
-              } else {
-                window.location.reload();
-              }
-            } else {
-              alert(data.message || '보안키가 일치하지 않습니다.');
-              window.clearPin();
-            }
-          } catch (error) {
-            console.error('PIN submit error:', error);
-            alert('인증 처리 중 오류가 발생했습니다.');
-            window.clearPin();
-          }
-        };
-
         document.addEventListener('DOMContentLoaded', function() {
           const gateLinks = document.querySelectorAll('[data-admin-gate="true"]');
-          const isOwnerDashboardAllowed = {% if request.session.owner_dashboard_allowed %}true{% else %}false{% endif %};
+          const allowedScopes = {
+            dashboard: {% if request.session.owner_dashboard_allowed %}true{% else %}false{% endif %},
+            mypage: {% if request.session.owner_mypage_allowed %}true{% else %}false{% endif %},
+          };
           const currentUrlName = "{{ request.resolver_match.url_name }}";
           
-          // 1. 클릭 게이트웨이 로직
           gateLinks.forEach(link => {
             link.addEventListener('click', function(e) {
-              if (!isOwnerDashboardAllowed) {
+              const targetScope = this.dataset.adminGateScope || 'dashboard';
+              if (!allowedScopes[targetScope]) {
                 e.preventDefault();
                 const targetUrl = this.href;
-                window.openAdminPinModal('header', targetUrl, '보안키를 입력해 주세요.');
+                const message = targetScope === 'mypage'
+                  ? '내 페이지 접근을 위해 관리자 보안키를 입력해 주세요.'
+                  : '파트너 센터 접근을 위해 관리자 보안키를 입력해 주세요.';
+                window.openAdminPinModal('header', targetUrl, message, targetScope);
               }
             });
           });
 
-          // 2. 페이지 로드 시 자동 체크 로직 (보안 영역 진입 시 세션 체크)
-          const protectedViewNames = [
-            'partner_dashboard', 
-            'partner_mypage', 
-            'partner_designer_management',
-            'partner_designer_signup',
-            'partner_designer_delete',
-            'partner_customer_detail',
-            'partner_customer_reanalysis_start'
-          ];
-          
-          if (protectedViewNames.includes(currentUrlName) && !isOwnerDashboardAllowed) {
-            // 보호 영역인데 세션이 없다면 즉시 모달 트리거
-            window.openAdminPinModal('dashboard', '', '보안을 위해 관리자 보안키를 입력해 주세요.');
+          const protectedViewScopeMap = {
+            partner_dashboard: 'dashboard',
+            partner_designer_management: 'dashboard',
+            partner_designer_signup: 'dashboard',
+            partner_designer_delete: 'dashboard',
+            partner_customer_detail: 'dashboard',
+            partner_customer_reanalysis_start: 'dashboard',
+            partner_mypage: 'mypage',
+          };
+
+          const currentScope = protectedViewScopeMap[currentUrlName];
+          if (currentScope && !allowedScopes[currentScope]) {
+            const currentUrl = window.location.pathname + window.location.search;
+            const message = currentScope === 'mypage'
+              ? '내 페이지 접근을 위해 관리자 보안키를 입력해 주세요.'
+              : '보안을 위해 관리자 보안키를 입력해 주세요.';
+            window.openAdminPinModal('current-view', currentUrl, message, currentScope);
           }
         });
       })();


### PR DESCRIPTION
## 💡 작업 내용 (Changes)
**파트너 포털 인증 안정화 및 디자이너 대시보드 권한 분리 작업**

1. **파트너 포털 로그인 & 핀 번호(PIN) 인증 로직 개선 및 안정화**
   - 기존 평문으로 저장·비교되던 `admin_pin` 값을 해싱(Hash) 보안 값으로 암호화하여 저장하도록 마이그레이션 적용 및 `front_views.py` 로그인 비교 로직 수정
   - 매장/디자이너 로그인 시 무한 리다이렉트 현상 및 PIN 모달 창이 닫히지 않던 프론트 단(`base_site.html`) 버그 수정 완료

2. **디자이너 조회(`MultipleObjectsReturned`) 에러 대응**
   - 과도기 모델(uuid 신규 체계와 정수형 legacy ID 혼용)로 인해 발생하던 모델 조회 오류 해결
   - 동일한 `backend_designer_id`를 가진 객체 간 충돌을 방지하기 위해 반드시 현재 세션의 `shop_id`(`get_legacy_admin_id`)를 조건으로 명시하도록 필터링 수정! (`partner_verify` 로직 안정화)

3. **대시보드 및 트렌드 리포트 데이터 명확한 분리**
   - 공통 대시보드 API(`LegacyAdminTrendReportView`, `LegacyAllClientsView`) 호출 시 `designer` 필터값이 들어가지 않아 디자이너가 로그인해도 전체 매장 데이터가 노출되던 취약점 수정 (수동으로 `designer=designer` 인자 주입)
   - 프론트(`index.html`)에서 디자이너 전용으로 로그인 시 대시보드 타이틀을 "XX 매장 현황"에서 "**XX 디자이너 담당 고객 현황**"으로 동적 노출하도록 분기 처리 완료
   - 디자이너 세션에 불필요한 '디자이너별 고객수' 탭은 자동으로 블라인드 처리.

## 📌 리뷰어 참고 사항 & 테스트 방법
- 브랜치 체크아웃 후 `python manage.py runserver`
- 매장 파트너 관리자 접속 후 디자이너 대시보드로 진입하여 PIN 번호 입력 모달이 원활하게 닫히는지 확인
- 디자이너 세션으로 로그인 시 트렌드 리포트와 고객 현황이 매장 전체 수치가 아닌 실제 자신이 담당한 고객만 필터링되어 출력되는지 검증해주세요! 🎉
