### PR TITLE
fix: 추천 결과 동시 생성 시 발생하는 PK 중복 (UniqueViolation) 문제 해결

### DIFF
--- a/app/api/v1/services_django.py
+++ b/app/api/v1/services_django.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.db import connection, transaction
+from django.db import connection, transaction, IntegrityError
 from django.db.models import Count, Max, Q
 from django.utils import timezone
 
@@ -421,8 +421,6 @@ def _persist_legacy_generated_batch(
 
     created_at = timezone.now()
     batch_id = uuid.uuid4()
-    result_id = _next_legacy_pk(LegacyClientResult, "result_id")
-    next_detail_id = _next_legacy_pk(LegacyClientResultDetail, "detail_id")
     analysis_id = getattr(analysis, "id", None) or getattr(analysis, "analysis_id", None) or 0
     survey_payload = _build_generation_survey_payload(client=client, survey=survey)
     survey_snapshot = {
@@ -452,8 +450,7 @@ def _persist_legacy_generated_batch(
         analysis_snapshot=analysis_snapshot,
     )
 
-    LegacyClientResult.objects.create(
-        result_id=result_id,
+    result_obj = LegacyClientResult.objects.create(
         analysis_id=analysis_id,
         client_id=legacy_client_id,
         selected_hairstyle_id=None,
@@ -478,17 +475,14 @@ def _persist_legacy_generated_batch(
 
     rows: list[SimpleNamespace] = []
     for item in normalized_items:
-        detail_id = next_detail_id
-        next_detail_id += 1
         reasoning_snapshot = dict(item.get("reasoning_snapshot") or {})
         reasoning_snapshot["recommendation_stage"] = recommendation_stage
         persisted_simulation_image_reference = _resolve_persistable_display_image_reference(
             simulation_image_url=item.get("simulation_image_url"),
             sample_image_url=item.get("sample_image_url"),
         )
-        LegacyClientResultDetail.objects.create(
-            detail_id=detail_id,
-            result_id=result_id,
+        detail_obj = LegacyClientResultDetail.objects.create(
+            result_id=result_obj.result_id,
             hairstyle_id=item["style_id"],
             rank=item.get("rank", 0),
             similarity_score=float(item.get("match_score") or 0.0),
@@ -526,7 +520,7 @@ def _persist_legacy_generated_batch(
                     "simulation_image_url": persisted_simulation_image_reference,
                     "sample_image_url": item.get("sample_image_url"),
                 },
-                detail_id=detail_id,
+                detail_id=detail_obj.detail_id,
             )
         )
 

--- a/app/models_model_team.py
+++ b/app/models_model_team.py
@@ -126,7 +126,7 @@ class LegacyClientAnalysis(models.Model):
 
 
 class LegacyClientResult(models.Model):
-    result_id = models.IntegerField(primary_key=True)
+    result_id = models.AutoField(primary_key=True)
     analysis_id = models.IntegerField()
     client_id = models.CharField(max_length=255)
     selected_hairstyle_id = models.IntegerField(null=True, blank=True)
@@ -154,7 +154,7 @@ class LegacyClientResult(models.Model):
 
 
 class LegacyClientResultDetail(models.Model):
-    detail_id = models.IntegerField(primary_key=True)
+    detail_id = models.AutoField(primary_key=True)
     result_id = models.IntegerField()
     hairstyle_id = models.IntegerField()
     rank = models.IntegerField()


### PR DESCRIPTION
**1. 발생 문제 (Issue)**
- `client_result` 및 `client_result_detail` 테이블에 추천 결과를 저장할 때, `IntegrityError (duplicate key value violates unique constraint)`가 발생하는 버그가 있었습니다.
- 기존 코드에서 DB 기본키(PK)를 `_next_legacy_pk()` 함수를 통해 애플리케이션 단에서 `Max(id) + 1`을 조회해 수동 부여하고 있었습니다. 
- 이로 인해 RunPod 시뮬레이션 파이프라인에서 추천 결과 여러 건이 거의 동시에 처리될 때, 여러 쓰레드(요청)가 같은 `Max(id)`를 바라보며 번호 중복(Race Condition)이 발생하는 것이 원인입니다.

**2. 작업 내용 (Changes)**
- DB와 장고 구조에서 수동으로 번호를 배부하지 않고 데이터베이스 기본 설정(`Auto Increment / SERIAL`)을 따르도록 구조를 마이그레이션했습니다.
- `app/models_model_team.py`
  - `LegacyClientResult.result_id`의 타입을 `IntegerField` -> `AutoField`로 변경하여 데이터베이스의 자동 증가값을 매핑하도록 지정
  - `LegacyClientResultDetail.detail_id` 역시 `AutoField`로 변경
- `app/api/v1/services_django.py`
  - 동시성 충돌을 유발하던 `_next_legacy_pk()` 수동 부여 로직 삭제
  - 객체 생성(`objects.create`) 시 `result_id`와 `detail_id`를 파라미터로 넘겨주지 않도록 제거하여 근본적인 동시성 충돌의 원인을 차단했습니다.
