### PR TITLE
fix: Gunicorn worker timeout 추가로 AWS EB 추천 결과 미응답 문제 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ RUN mkdir -p storage/captures storage/processed storage/synthetic
 EXPOSE 8000
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
-CMD ["sh", "-c", "python manage.py collectstatic --noinput && python manage.py verify_static_manifest --require shared/styles/base.css && python manage.py migrate --noinput && gunicorn --bind 0.0.0.0:8000 --pythonpath /app mirrai_project.wsgi:application"]
+CMD ["sh", "-c", "python manage.py collectstatic --noinput && python manage.py verify_static_manifest --require shared/styles/base.css && python manage.py migrate --noinput && gunicorn --bind 0.0.0.0:8000 --timeout 120 --pythonpath /app mirrai_project.wsgi:application"]


### PR DESCRIPTION
## 문제 요약

AWS Elastic Beanstalk 환경에서 `customer/recommendations` 페이지가 로딩되지 않는 문제 수정.
로컬(docker-compose) 환경에서는 정상 동작하나 EB 환경에서만 응답이 오지 않음.

## 원인 분석

Gunicorn의 기본 worker timeout이 **30초**인데,  
추천 엔드포인트(`/api/v1/analysis/recommendations/`)는 내부적으로 최대 **45초** 이상 대기할 수 있음.

| 단계 | 최대 소요 시간 |
|------|--------------|
| 분석 완료 폴링 (`CURRENT_RECOMMENDATION_WAIT_POLICY`) | 45초 (3초 간격) |
| RunPod API 호출 (`_post_runpod`) | 최대 120초 |

→ 30초 초과 시 Gunicorn이 worker를 강제 종료 → 클라이언트에 응답 없음 (502/504)

로컬에서는 Django dev server(`runserver`) 또는 docker-compose가 타임아웃 제한 없이 동작하므로 재현 불가.

## 변경 사항

**`Dockerfile`**

```diff
gunicorn --bind 0.0.0.0:8000 --pythonpath /app mirrai_project.wsgi:application
gunicorn --bind 0.0.0.0:8000 --timeout 120 --pythonpath /app mirrai_project.wsgi:application
```

`--timeout 120` 추가: RunPod 최대 응답 대기 시간(120초)에 맞춰 worker timeout 설정.

## 추가 권장 조치

AWS EB 콘솔에서 **ALB idle timeout도 120초 이상**으로 설정 필요.  
(기본값 60초 → `EC2 > Load Balancers > Attributes > Idle timeout`)

## 테스트

- [x] 로컬 docker-compose 환경에서 정상 동작 확인
- [ ] EB 재배포 후 `customer/recommendations` 응답 확인
- [ ] RunPod 응답 지연 상황에서 45초+ 요청 정상 처리 확인

## 관련 파일

- `Dockerfile` — gunicorn timeout 추가
- `app/services/ai_facade.py` — RunPod 통신 로직 (timeout: `(5, 120)`)
- `app/api/v1/services_django.py` — 추천 wait policy (`timeout_seconds=45.0`)