### PR TITLE
fix: 파트너 로그인 시 SessionInterrupted 에러 수정

### DIFF
--- a/app/session_state.py
+++ b/app/session_state.py
@@ -91,13 +91,16 @@ def get_session_customer(*, request: HttpRequest) -> Client | None:
 
 
 def set_admin_session(*, request: HttpRequest, admin: AdminAccount) -> None:
+    # 로그인 시 세션 키 순환: 만료·삭제된 세션으로 UPDATE를 시도해 발생하는
+    # SessionInterrupted 방지 + 세션 고정(session fixation) 공격 방지
+    request.session.cycle_key()
     request.session[ADMIN_ID_SESSION_KEY] = str(admin.id)
     request.session[ADMIN_LEGACY_ID_SESSION_KEY] = get_legacy_admin_id(admin=admin)
     request.session[ADMIN_STORE_NAME_SESSION_KEY] = admin.store_name
     request.session[ADMIN_NAME_SESSION_KEY] = admin.name
     request.session[OWNER_DASHBOARD_ALLOWED_SESSION_KEY] = False
     request.session[OWNER_MYPAGE_ALLOWED_SESSION_KEY] = False
-    
+
     # 매장 세션은 24시간 유지
     request.session.set_expiry(24 * 60 * 60)
     request.session.modified = True


### PR DESCRIPTION

## 요약

- 파트너 로그인(`/partner/verify/`) 시 서버에 `SessionInterrupted` 에러가 반복 출력되던 문제 수정

## 원인

만료되거나 다른 탭에서 삭제된 세션 쿠키를 가진 상태로 로그인 요청을 보내면 다음 흐름으로 에러가 발생했습니다.

1. Django 세션 미들웨어가 기존 세션 키로 세션을 로드 (쿠키는 있지만 DB 레코드는 없는 상태)
2. `set_admin_session()`에서 세션 데이터 수정 (`modified = True`)
3. 응답 시 미들웨어가 `session.save()` 호출 → DB에서 기존 키로 `UPDATE` 시도
4. DB에 해당 레코드가 없으므로 `Forced update did not affect any rows` → `SessionInterrupted`

## 변경 사항

**`app/session_state.py` — `set_admin_session()`**

로그인 시 `request.session.cycle_key()`를 호출하도록 추가했습니다.

`cycle_key()`는 현재 세션 데이터를 새로운 세션 키로 이전하면서 DB에 `INSERT`를 먼저 수행합니다. 이후의 모든 `session.save()`는 새 레코드에 대한 `UPDATE`이므로 항상 성공합니다. Django의 내장 `auth.login()`이 동일한 이유로 이 패턴을 사용합니다.

부수 효과로 세션 고정(Session Fixation) 공격도 방지됩니다.

## 테스트 체크리스트

- [ ] 파트너 매장 관리자 로그인 정상 동작 확인
- [ ] 디자이너 PIN 로그인 정상 동작 확인
- [ ] 세션 만료 후 재로그인 시 에러 없음 확인
- [ ] 서버 로그에 `SessionInterrupted` 미출력 확인