### PR TITLE
feat: improve chatbot responsive UI and add authorized basic info upd…

### DIFF
--- a/app/front_views.py
+++ b/app/front_views.py
@@ -858,6 +858,36 @@ def admin_mypage_page(request):
         if admin_obj is None:
             return JsonResponse({"status": "error", "message": "관리자 정보를 찾을 수 없습니다."}, status=404)
 
+        if action == "update_info":
+            current_pin = (request.POST.get("current_pin") or "").strip()
+            if not _matches_admin_pin(raw_pin=current_pin, stored_pin=admin_obj.admin_pin):
+                return JsonResponse({"status": "error", "message": "보안키가 일치하지 않습니다."}, status=401)
+
+            store_name = (request.POST.get("store_name") or "").strip()
+            manager_name = (request.POST.get("name") or "").strip()
+            phone = (request.POST.get("phone") or "").strip()
+
+            if not store_name or not manager_name or not phone:
+                return JsonResponse({"status": "error", "message": "모든 필드를 입력해 주세요."}, status=400)
+
+            updated_fields = []
+            if admin_obj.store_name != store_name:
+                admin_obj.store_name = store_name
+                updated_fields.append("store_name")
+            if admin_obj.name != manager_name:
+                admin_obj.name = manager_name
+                updated_fields.append("name")
+            if admin_obj.phone != phone:
+                admin_obj.phone = phone
+                updated_fields.append("phone")
+
+            if updated_fields:
+                admin_obj.save(update_fields=updated_fields)
+                _sync_admin_account_state(request=request, admin_obj=admin_obj)
+                return JsonResponse({"status": "success", "message": "기본 정보가 성공적으로 수정되었습니다."})
+            
+            return JsonResponse({"status": "success", "message": "변경사항이 없습니다."})
+
         if action == "change_password":
             current_password = (request.POST.get("current_password") or "").strip()
             new_password = (request.POST.get("new_password") or "").strip()

--- a/static/shared/styles/base.css
+++ b/static/shared/styles/base.css
@@ -395,7 +395,8 @@ a {
   position: fixed;
   bottom: 110px;
   right: 32px;
-  width: 400px;
+  width: 800px;
+  max-width: calc(100vw - 64px);
   height: 600px;
   max-height: calc(100vh - 150px);
   background: white;

--- a/templates/admin/mypage.html
+++ b/templates/admin/mypage.html
@@ -395,19 +395,20 @@
     <section class="mypage-section">
       <div class="mypage-section-head">
         <h3>기본 정보</h3>
+        <button id="openInfoEditBtn" type="button" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; font-weight: 600;">정보 수정</button>
       </div>
       <div class="mypage-info-list">
         <div class="mypage-row">
           <span class="mypage-label">매장명</span>
-          <span class="mypage-value">{{ active_shop.store_name }}</span>
+          <span id="displayStoreName" class="mypage-value">{{ active_shop.store_name }}</span>
         </div>
         <div class="mypage-row">
           <span class="mypage-label">관리자명</span>
-          <span class="mypage-value">{{ active_shop.name }}</span>
+          <span id="displayManagerName" class="mypage-value">{{ active_shop.name }}</span>
         </div>
         <div class="mypage-row">
           <span class="mypage-label">연락처</span>
-          <span class="mypage-value">{{ active_shop.phone }}</span>
+          <span id="displayPhone" class="mypage-value">{{ active_shop.phone }}</span>
         </div>
         <div class="mypage-row">
           <span class="mypage-label">사업자번호</span>
@@ -418,29 +419,54 @@
 
     <section class="mypage-section">
       <div class="mypage-section-head">
-        <h3>보안 설정</h3>
-        <button id="openKeypadBtn" type="button" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; font-weight: 600;">보안키 변경</button>
+        <h3>계정 및 보안 관리</h3>
       </div>
 
-      <div class="mypage-security-stack">
-        <div class="mypage-security-card">
-          <div class="mypage-security-icon">🔑</div>
+      <div class="mypage-security-stack" style="gap: 12px;">
+        <!-- 통합된 보안 관리 리스트 -->
+        <div class="mypage-security-card" style="padding: 16px 24px; background: white; border: 1px solid var(--line);">
           <div class="mypage-security-meta">
-            <p class="mypage-security-title">관리자 보안키 (PIN)</p>
-            <p class="mypage-security-copy">매장 내 민감한 정보 접근 시 사용하는 4자리 보안키입니다.</p>
+            <p class="mypage-security-title" style="font-size: 14px;">관리자 보안키 (PIN)</p>
+            <p class="mypage-security-copy" style="font-size: 12px;">매장 내 민감한 정보 접근 시 사용</p>
           </div>
+          <button id="openKeypadBtn" type="button" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; font-weight: 600;">변경</button>
         </div>
 
-        <div class="mypage-security-card">
-          <div class="mypage-security-icon">🔒</div>
+        <div class="mypage-security-card" style="padding: 16px 24px; background: white; border: 1px solid var(--line);">
           <div class="mypage-security-meta">
-            <p class="mypage-security-title">관리자 로그인 비밀번호</p>
-            <p class="mypage-security-copy">파트너 센터 로그인에 사용하는 비밀번호를 내 페이지에서 바로 변경할 수 있습니다.</p>
+            <p class="mypage-security-title" style="font-size: 14px;">관리자 로그인 비밀번호</p>
+            <p class="mypage-security-copy" style="font-size: 12px;">파트너 센터 접속 비밀번호</p>
           </div>
-          <button id="openPasswordChangeBtn" type="button" class="btn btn-dark mypage-security-action">비밀번호 변경</button>
+          <button id="openPasswordChangeBtn" type="button" class="btn btn-dark" style="height: 36px; padding: 0 16px; font-size: 13px; font-weight: 600;">변경</button>
         </div>
       </div>
     </section>
+  </div>
+</div>
+
+<!-- 기본 정보 수정 팝업 -->
+<div id="infoEditOverlay" class="password-change-overlay">
+  <div class="password-change-container">
+    <div class="pin-change-title">기본 정보 수정</div>
+    <div class="pin-change-subtitle">매장 및 관리자 정보를 수정할 수 있습니다.</div>
+
+    <form id="infoEditForm" class="password-change-form">
+      <label for="storeNameInput" class="password-change-label">매장명</label>
+      <input id="storeNameInput" name="store_name" type="text" class="password-change-input" value="{{ active_shop.store_name }}" placeholder="매장명 입력">
+
+      <label for="managerNameInput" class="password-change-label">관리자명</label>
+      <input id="managerNameInput" name="name" type="text" class="password-change-input" value="{{ active_shop.name }}" placeholder="관리자명 입력">
+
+      <label for="phoneInput" class="password-change-label">연락처</label>
+      <input id="phoneInput" name="phone" type="text" class="password-change-input" value="{{ active_shop.phone }}" placeholder="연락처 입력 (숫자만)">
+
+      <p id="infoEditMessage" class="password-change-message"></p>
+
+      <div class="password-change-actions">
+        <button id="closeInfoEditBtn" type="button" class="btn btn-dark">취소</button>
+        <button type="submit" class="btn btn-primary">저장하기</button>
+      </div>
+    </form>
   </div>
 </div>
 
@@ -536,8 +562,101 @@
     const keypadButtons = document.querySelectorAll('.pin-change-btn[data-val]');
     const backBtn = document.getElementById('pinChangeBack');
 
+    const infoOverlay = document.getElementById('infoEditOverlay');
+    const openInfoBtn = document.getElementById('openInfoEditBtn');
+    const closeInfoBtn = document.getElementById('closeInfoEditBtn');
+    const infoForm = document.getElementById('infoEditForm');
+    const infoMessageEl = document.getElementById('infoEditMessage');
+
+    const displayStoreName = document.getElementById('displayStoreName');
+    const displayManagerName = document.getElementById('displayManagerName');
+    const displayPhone = document.getElementById('displayPhone');
+
     const passwordForm = document.getElementById('passwordChangeForm');
     const passwordMessageEl = document.getElementById('passwordChangeMessage');
+
+    function openInfoModal() {
+      if (warningOverlay) warningOverlay.classList.remove('is-active');
+      setInfoMessage('');
+      infoOverlay.classList.add('is-active');
+    }
+
+    function closeInfoModal() {
+      infoOverlay.classList.remove('is-active');
+      restoreWarningIfNeeded();
+    }
+
+    function setInfoMessage(message, type = '') {
+      if (!infoMessageEl) return;
+      infoMessageEl.textContent = message || '';
+      infoMessageEl.classList.remove('is-error', 'is-success');
+      if (type) infoMessageEl.classList.add(type === 'error' ? 'is-error' : 'is-success');
+    }
+
+    function submitInfoUpdate(event) {
+      event.preventDefault();
+      const storeName = document.getElementById('storeNameInput').value.trim();
+      const managerName = document.getElementById('managerNameInput').value.trim();
+      const phone = document.getElementById('phoneInput').value.trim();
+
+      if (!storeName || !managerName || !phone) {
+        setInfoMessage('모든 필드를 입력해 주세요.', 'error');
+        return;
+      }
+
+      if (!confirm('입력하신 정보로 변경하시겠습니까?')) {
+        return;
+      }
+
+      // 데이터를 임시 저장하고 PIN 입력 단계로 전환
+      pendingInfoData = { storeName, managerName, phone };
+      infoOverlay.classList.remove('is-active');
+      openKeypad('VERIFY_FOR_INFO_UPDATE');
+    }
+
+    async function finalizeInfoUpdate(pin) {
+      if (!pendingInfoData) return;
+
+      try {
+        const formData = new URLSearchParams();
+        formData.append('action', 'update_info');
+        formData.append('current_pin', pin);
+        formData.append('store_name', pendingInfoData.storeName);
+        formData.append('name', pendingInfoData.managerName);
+        formData.append('phone', pendingInfoData.phone);
+
+        const response = await fetch(window.location.pathname, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'X-CSRFToken': '{{ csrf_token }}',
+          },
+          body: formData.toString(),
+        });
+
+        const data = await response.json();
+        if (!response.ok) {
+          alert(data.message || '보안키가 일치하지 않거나 오류가 발생했습니다.');
+          inputBuffer = '';
+          updatePinUI();
+          return;
+        }
+
+        if (displayStoreName) displayStoreName.textContent = pendingInfoData.storeName;
+        if (displayManagerName) displayManagerName.textContent = pendingInfoData.managerName;
+        if (displayPhone) displayPhone.textContent = pendingInfoData.phone;
+
+        closeKeypad();
+        alert(data.message || '정보가 성공적으로 수정되었습니다.');
+      } catch (error) {
+        console.error('Info update error:', error);
+        alert('서버 처리 중 오류가 발생했습니다.');
+        closeKeypad();
+      }
+    }
+
+    if (openInfoBtn) openInfoBtn.addEventListener('click', openInfoModal);
+    if (closeInfoBtn) closeInfoBtn.addEventListener('click', closeInfoModal);
 
     if (openPinBtn && pinSecurityCard) {
       openPinBtn.classList.add('mypage-security-action');
@@ -552,6 +671,7 @@
     let inputBuffer = '';
     let verifiedCurrentPin = '';
     let newPinBuffer = '';
+    let pendingInfoData = null;
 
     function restoreWarningIfNeeded() {
       if (isMypageVerified && isDefaultAdminPin && warningOverlay && !pinOverlay.classList.contains('is-active')) {
@@ -565,8 +685,9 @@
       }
     });
 
-    function openKeypad() {
+    function openKeypad(targetState = 'VERIFY_CURRENT') {
       resetKeypad();
+      state = targetState;
       if (warningOverlay) {
         warningOverlay.classList.remove('is-active');
       }
@@ -578,6 +699,7 @@
 
     function closeKeypad() {
       pinOverlay.classList.remove('is-active');
+      pendingInfoData = null;
       restoreWarningIfNeeded();
     }
 
@@ -593,6 +715,9 @@
       if (state === 'VERIFY_CURRENT') {
         titleEl.textContent = '현재 보안키 확인';
         subEl.textContent = '현재 사용 중인 보안키 4자리를 입력해 주세요.';
+      } else if (state === 'VERIFY_FOR_INFO_UPDATE') {
+        titleEl.textContent = '관리자 인증';
+        subEl.textContent = '정보 수정을 승인하려면 보안키 4자리를 입력해 주세요.';
       } else if (state === 'ENTER_NEW') {
         titleEl.textContent = '새 보안키 설정';
         subEl.textContent = '변경할 새로운 보안키 4자리를 입력해 주세요.';
@@ -650,6 +775,11 @@
     }
 
     async function processPinStep() {
+      if (state === 'VERIFY_FOR_INFO_UPDATE') {
+        await finalizeInfoUpdate(inputBuffer);
+        return;
+      }
+
       if (state === 'VERIFY_CURRENT') {
         const verified = await verifyCurrentPin(inputBuffer);
         if (verified) {
@@ -836,6 +966,11 @@
 
     if (backBtn) {
       backBtn.addEventListener('click', handlePinBack);
+    }
+
+    // Force re-bind the infoForm submit to the correct logic
+    if (infoForm) {
+      infoForm.onsubmit = submitInfoUpdate;
     }
   })();
 </script>


### PR DESCRIPTION
## 1. 주요 작업 내용

### 챗봇 UI 개선

- **사이즈 확장:** 챗봇 패널의 너비를 기존 400px에서 800px로 2배 확장하여 시인성을 높였습니다.
- **완전 반응형 적용:** `max-width: calc(100vw - 64px)` 속성을 추가하여 모바일 및 중소형 화면에서도 화면 밖으로 나가지 않고 자연스럽게 크기가 조절되도록 개선했습니다.

### 마이페이지(Partner Mypage) 기능 강화

- **기본 정보 수정 기능 추가:** 매장명, 관리자명, 연락처를 직접 수정할 수 있는 팝업(모달) UI를 구현했습니다.
- **보안 프로세스 강화:**
  - 정보 수정 시 즉시 반영되지 않고, 사용자의 확인 컨펌 과정을 추가했습니다.
  - 최종 저장을 위해 관리자 보안키(PIN)를 입력받는 인증 절차를 도입했습니다.
  - 서버 측에서도 PIN을 이중 검증하여 비정상적인 데이터 접근을 차단했습니다.
- **UI/UX 통합 및 정돈:**
  - 보안 설정(PIN/비밀번호) 항목을 하나의 '계정 및 보안 관리' 섹션으로 통합하여 화면 구성을 최적화했습니다.
  - 상황에 따라 PIN 입력창의 제목이 동적으로 변경되도록 개선했습니다 (보안키 변경 시: '현재 보안키 확인' / 정보 수정 시: '관리자 인증').

## 2. 수정 파일 리스트

- `static/shared/styles/base.css`: 챗봇 반응형 스타일 수정
- `app/front_views.py`: 기본 정보 수정(`update_info`) 백엔드 로직 및 보안 검증 추가
- `templates/admin/mypage.html`: 정보 수정 UI 추가, 보안 통합 레이아웃 리팩토링, 인증 흐름 JS 구현
- `data/rag/stores/chromadb_chatbot/chroma.sqlite3`: (자동 업데이트)

## 3. 결과 및 확인 사항

- `partner/mypage/` 페이지에서 '정보 수정' 버튼을 통한 안전한 데이터 업데이트가 가능합니다.
- 모든 UI 변경 사항은 반응형으로 작동하여 다양한 디바이스에서 최적의 화면을 제공합니다.
- 중복 이벤트 리스너를 제거하여 컨펌 창이 중복으로 뜨는 현상을 해결했습니다.