### PR TITLE
fix: Harden EB deploy checks and optional startup tasks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,8 @@ jobs:
         env:
           VERSION_LABEL: deploy-${{ github.sha }}-${{ github.run_number }}
         run: |
+          echo "EXPECTED_VERSION_LABEL=$VERSION_LABEL" >> $GITHUB_ENV
+
           echo "Waiting for Elastic Beanstalk environment to become Ready before deploy..."
           ATTEMPTS=0
           MAX_ATTEMPTS=60
@@ -134,6 +136,7 @@ jobs:
           echo "Waiting for Elastic Beanstalk deployment to finish..."
           ATTEMPTS=0
           MAX_ATTEMPTS=120
+          EXPECTED_VERSION_LABEL="${EXPECTED_VERSION_LABEL:?EXPECTED_VERSION_LABEL is required}"
           while true; do
             read -r STATUS HEALTH ABORTABLE VERSION_LABEL < <(aws elasticbeanstalk describe-environments \
               --application-name "$EB_APP_NAME" \
@@ -141,9 +144,31 @@ jobs:
               --query "Environments[0].[Status,Health,AbortableOperationInProgress,VersionLabel]" \
               --output text)
 
-            echo "Environment status=$STATUS health=$HEALTH abortable=$ABORTABLE version=$VERSION_LABEL"
+            echo "Environment status=$STATUS health=$HEALTH abortable=$ABORTABLE version=$VERSION_LABEL expected=$EXPECTED_VERSION_LABEL"
 
             if [ "$STATUS" = "Ready" ]; then
+              if [ "$VERSION_LABEL" != "$EXPECTED_VERSION_LABEL" ]; then
+                echo "Environment became Ready but is serving version '$VERSION_LABEL' instead of expected '$EXPECTED_VERSION_LABEL'."
+                echo "Recent Elastic Beanstalk events:"
+                aws elasticbeanstalk describe-events \
+                  --environment-name "$EB_ENV_NAME" \
+                  --max-records 20 || true
+                exit 1
+              fi
+
+              if [ "$HEALTH" = "Red" ]; then
+                echo "Environment became Ready but health is Red. Treating deployment as failed."
+                echo "Recent Elastic Beanstalk events:"
+                aws elasticbeanstalk describe-events \
+                  --environment-name "$EB_ENV_NAME" \
+                  --max-records 20 || true
+                echo "Elastic Beanstalk health details:"
+                aws elasticbeanstalk describe-environment-health \
+                  --environment-name "$EB_ENV_NAME" \
+                  --attribute-names All || true
+                exit 1
+              fi
+
               echo "Elastic Beanstalk deployment finished."
               break
             fi

--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ python manage.py runserver
 
 - `NCS_PDF_SYNC_SOURCE_DIR=/mnt/mirrai-ncs-pdfs`
 - `NCS_PDF_SYNC_STRICT=1`
+- `OPTIONAL_STARTUP_TASKS_BLOCKING=0`
+- `NCS_PDF_SYNC_BLOCKING=0`
+- `BOOTSTRAP_RAG_ASSETS_BLOCKING=0`
 - `NCS_EFS_FILE_SYSTEM_ID`
 - `NCS_EFS_REGION`
 - `NCS_EFS_ACCESS_POINT_ID` (선택)
@@ -224,6 +227,7 @@ python manage.py runserver
 - EB는 `Dockerrun.aws.json`에서 host `80` -> container `8000`으로 연결한다.
 - health check 대응은 `/` 와 `/health/`에서 처리한다.
 - startup 체인은 `collectstatic -> verify_static_manifest -> migrate -> gunicorn` 이다.
+- NCS PDF sync / RAG bootstrap은 기본 non-blocking background 작업으로 분리할 수 있다.
 
 헬스가 깨질 때는 아래를 먼저 본다.
 
@@ -231,6 +235,7 @@ python manage.py runserver
 - startup migration 실패 여부
 - Redis 접속 지연 여부
 - EFS mount 경고 여부
+- optional startup task blocking 여부
 - EB 이벤트 / 컨테이너 로그
 
 ## 관련 문서

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,6 +15,9 @@ set -eu
 : "${NCS_PDF_SYNC_OVERWRITE:=0}"
 : "${NCS_PDF_SYNC_STRICT:=0}"
 : "${NCS_PACKAGED_EXAMPLE_PDF_BOOTSTRAP:=1}"
+: "${OPTIONAL_STARTUP_TASKS_BLOCKING:=0}"
+: "${NCS_PDF_SYNC_BLOCKING:=${OPTIONAL_STARTUP_TASKS_BLOCKING}}"
+: "${BOOTSTRAP_RAG_ASSETS_BLOCKING:=${OPTIONAL_STARTUP_TASKS_BLOCKING}}"
 
 export BOOTSTRAP_RAG_ASSETS
 export TIME_ZONE
@@ -28,20 +31,51 @@ export NCS_PDF_SYNC_SOURCE_DIR
 export NCS_PDF_SYNC_OVERWRITE
 export NCS_PDF_SYNC_STRICT
 export NCS_PACKAGED_EXAMPLE_PDF_BOOTSTRAP
+export OPTIONAL_STARTUP_TASKS_BLOCKING
+export NCS_PDF_SYNC_BLOCKING
+export BOOTSTRAP_RAG_ASSETS_BLOCKING
 
 BUNDLED_NCS_PDF_DIR="/app/data/rag/sources/ncs"
 
-if [ -n "${NCS_PDF_SYNC_SOURCE_DIR}" ] && [ "${NCS_PACKAGED_EXAMPLE_PDF_BOOTSTRAP}" = "1" ]; then
-  mkdir -p "${NCS_PDF_SYNC_SOURCE_DIR}"
-  if ! find "${NCS_PDF_SYNC_SOURCE_DIR}" -maxdepth 1 -type f -name '*.pdf' | grep -q .; then
-    if find "${BUNDLED_NCS_PDF_DIR}" -maxdepth 1 -type f -name '*.pdf' | grep -q .; then
-      echo "[entrypoint] bootstrapping packaged example NCS PDFs into ${NCS_PDF_SYNC_SOURCE_DIR}"
-      cp -n "${BUNDLED_NCS_PDF_DIR}"/*.pdf "${NCS_PDF_SYNC_SOURCE_DIR}/"
+run_task() {
+  task_name="$1"
+  blocking="$2"
+  shift 2
+
+  if [ "${blocking}" = "1" ]; then
+    echo "[entrypoint] running ${task_name} in blocking mode"
+    "$@"
+    return $?
+  fi
+
+  echo "[entrypoint] starting ${task_name} in background"
+  (
+    set +e
+    "$@"
+    status=$?
+    if [ "${status}" -eq 0 ]; then
+      echo "[entrypoint] ${task_name} finished"
+    else
+      echo "[entrypoint] warning: ${task_name} failed with exit=${status}"
+    fi
+  ) &
+}
+
+run_ncs_pdf_sync() {
+  if [ -z "${NCS_PDF_SYNC_SOURCE_DIR}" ]; then
+    return 0
+  fi
+
+  if [ "${NCS_PACKAGED_EXAMPLE_PDF_BOOTSTRAP}" = "1" ]; then
+    mkdir -p "${NCS_PDF_SYNC_SOURCE_DIR}"
+    if ! find "${NCS_PDF_SYNC_SOURCE_DIR}" -maxdepth 1 -type f -name '*.pdf' | grep -q .; then
+      if find "${BUNDLED_NCS_PDF_DIR}" -maxdepth 1 -type f -name '*.pdf' | grep -q .; then
+        echo "[entrypoint] bootstrapping packaged example NCS PDFs into ${NCS_PDF_SYNC_SOURCE_DIR}"
+        cp -n "${BUNDLED_NCS_PDF_DIR}"/*.pdf "${NCS_PDF_SYNC_SOURCE_DIR}/"
+      fi
     fi
   fi
-fi
 
-if [ -n "${NCS_PDF_SYNC_SOURCE_DIR}" ]; then
   echo "[entrypoint] syncing NCS PDFs from ${NCS_PDF_SYNC_SOURCE_DIR}"
   if [ "${NCS_PDF_SYNC_OVERWRITE}" = "1" ] && [ "${NCS_PDF_SYNC_STRICT}" = "1" ]; then
     python manage.py sync_ncs_source_pdfs --source-dir "${NCS_PDF_SYNC_SOURCE_DIR}" --overwrite --strict
@@ -52,13 +86,25 @@ if [ -n "${NCS_PDF_SYNC_SOURCE_DIR}" ]; then
   else
     python manage.py sync_ncs_source_pdfs --source-dir "${NCS_PDF_SYNC_SOURCE_DIR}"
   fi
-fi
+}
 
-if [ "${BOOTSTRAP_RAG_ASSETS}" = "1" ]; then
+run_rag_bootstrap() {
+  if [ "${BOOTSTRAP_RAG_ASSETS}" != "1" ]; then
+    return 0
+  fi
+
   echo "[entrypoint] ensuring packaged RAG assets are available"
   if ! python manage.py bootstrap_rag_assets; then
     echo "[entrypoint] warning: packaged RAG asset bootstrap failed; continuing startup"
   fi
+}
+
+if [ -n "${NCS_PDF_SYNC_SOURCE_DIR}" ]; then
+  run_task "sync_ncs_source_pdfs" "${NCS_PDF_SYNC_BLOCKING}" run_ncs_pdf_sync
+fi
+
+if [ "${BOOTSTRAP_RAG_ASSETS}" = "1" ]; then
+  run_task "bootstrap_rag_assets" "${BOOTSTRAP_RAG_ASSETS_BLOCKING}" run_rag_bootstrap
 fi
 
 if [ "${ENABLE_TREND_SCHEDULER:-0}" = "1" ]; then

--- a/docs/elastic_beanstalk_deploy_checklist.md
+++ b/docs/elastic_beanstalk_deploy_checklist.md
@@ -99,6 +99,9 @@ NCS PDF를 EFS에서 읽을 때 확인:
 - `NCS_PDF_SYNC_OVERWRITE=0`
 - `NCS_PDF_SYNC_STRICT=1`
 - `NCS_PACKAGED_EXAMPLE_PDF_BOOTSTRAP=1`
+- `OPTIONAL_STARTUP_TASKS_BLOCKING=0`
+- `NCS_PDF_SYNC_BLOCKING=0`
+- `BOOTSTRAP_RAG_ASSETS_BLOCKING=0`
 - `NCS_EFS_FILE_SYSTEM_ID`
 - `NCS_EFS_REGION=ap-northeast-2`
 - `NCS_EFS_ACCESS_POINT_ID` (선택)
@@ -131,6 +134,16 @@ NCS PDF를 EFS에서 읽을 때 확인:
 3. migration 실패 여부
 4. static manifest 검증 실패 여부
 5. EFS mount warning/timeout 여부
+6. optional startup task가 blocking 모드로 묶여 startup을 지연시키는지 여부
+
+## 5-1. GitHub Actions 배포 판정 규칙
+
+현재 workflow는 아래 경우를 실패로 처리해야 한다.
+
+- 환경이 `Ready`가 되었지만 `VersionLabel`이 기대한 배포 버전과 다를 때
+- 환경이 `Ready`가 되었지만 `Health=Red`일 때
+
+즉 `Ready`만 보고 성공으로 끝내면 안 된다.
 
 ## 6. 다른 배포 repo에 업로드할 파일
 


### PR DESCRIPTION
## 개요
Elastic Beanstalk 배포 성공 판정을 더 엄격하게 만들고,
선택적 startup 작업이 앱 기동을 막지 않도록 엔트리포인트를 보강했습니다.
문서도 현재 동작 기준에 맞게 함께 정리했습니다.

## 변경 사항
- GitHub Actions EB 배포 판정 강화
  - 환경이 `Ready`여도 기대한 `VersionLabel`이 아니면 실패 처리
  - 환경이 `Ready`여도 `Health=Red`이면 실패 처리
  - 실패 시 최근 EB 이벤트와 health 정보를 출력하도록 보강
- `docker-entrypoint.sh` 개선
  - NCS PDF sync를 optional startup task로 분리
  - RAG bootstrap을 optional startup task로 분리
  - blocking / non-blocking 동작을 환경 변수로 제어 가능하도록 추가
- README 업데이트
  - optional startup task 관련 운영 메모 추가
- EB 배포 체크리스트 업데이트
  - 신규 startup 관련 환경 변수 반영
  - GitHub Actions 배포 실패 판정 규칙 문서화

## 수정 파일
- `.github/workflows/deploy.yml`
- `docker-entrypoint.sh`
- `README.md`
- `docs/elastic_beanstalk_deploy_checklist.md`

## 검증
- `bash -n docker-entrypoint.sh`

## 기대 효과
- EB가 실제로 실패한 배포를 성공으로 오판하는 경우를 줄임
- EFS / RAG 준비 작업이 앱 startup을 과도하게 지연시키는 문제를 완화
- 운영 환경 변수와 배포 동작 기준을 문서에서 바로 확인 가능
