### PR TITLE
index 문구와 위치 조정

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -8,18 +8,18 @@
     <p class="home-kicker">AI HAIR STYLING SOLUTION</p>
 
     {% if request.session.customer_id %}
-    <h2 class="hero-title">지금 고객에게 <span>시술 전 결과 방향</span>을 먼저 보여주세요</h2>
+    <h2 class="hero-title">현재 고객에게 맞는 <span>헤어 후보</span>를 바로 확인하세요</h2>
     <p class="section-copy home-hero-description">
-      MirrAI는 취향 입력과 얼굴 분석을 바탕으로 시술 전에 어울리는 스타일 방향을 먼저 확인하게 해, 기대와 실제 결과의 차이를 줄입니다.
+      MirrAI는 고객의 취향과 얼굴 특징을 함께 반영해 상담에 필요한 스타일 후보와 추천 근거를 정리합니다.
     </p>
     <div class="home-hero-actions">
       <a href="{% url 'customer_camera' %}" class="btn btn-primary" data-loading-cta="true" data-loading-label="분석 준비 중...">새 추천 시작</a>
       <a href="{% url 'customer_history' %}" class="btn btn-dark home-btn-ghost">추천 이력 보기</a>
     </div>
     {% elif request.session.admin_id or request.session.designer_id %}
-    <h2 class="hero-title">시술 전 결과 방향을 <span>먼저 확인하는</span> AI 헤어 가이드</h2>
+    <h2 class="hero-title">상담 전에 스타일 후보를 <span>정리하는</span> AI 헤어 가이드</h2>
     <p class="section-copy home-hero-description">
-      자르기 전에는 결과를 정확히 보기 어려운 헤어 서비스의 특성을 보완해, 고객이 시술 전에 어울리는 방향을 먼저 확인할 수 있게 합니다.
+      고객의 취향, 얼굴 특징, 이력을 한 화면에서 연결해 상담 흐름을 더 빠르고 명확하게 만듭니다.
     </p>
     <div class="home-hero-actions">
       {% if request.session.designer_id %}
@@ -31,9 +31,9 @@
       {% endif %}
     </div>
     {% else %}
-    <h2 class="hero-title">시술 전에 <span>가장 어울리는</span> 헤어 스타일을 먼저 확인하세요</h2>
+    <h2 class="hero-title">상담 전에 어울리는 <span>헤어 스타일</span>을 비교하세요</h2>
     <p class="section-copy home-hero-description">
-      헤어 시술은 결과를 미리 확인하기 어렵기 때문에, MirrAI는 취향 입력과 얼굴 분석을 통해 어울리는 결과 방향을 먼저 보여줍니다.
+      MirrAI는 취향 입력과 얼굴 분석을 바탕으로 고객에게 어울릴 스타일 후보와 추천 근거를 제안합니다.
     </p>
     <div class="home-hero-actions">
       <a href="{% url 'partner_login' %}?next={% url 'partner_designer_select' %}?next={% url 'customer_index' %}" class="btn btn-primary" data-loading-cta="true" data-loading-label="로그인 화면 준비 중...">분석 시작하기</a>
@@ -42,24 +42,24 @@
     {% endif %}
 
     <div class="home-pill-row">
-      <span class="home-pill">스타일 방향 입력</span>
-      <span class="home-pill">얼굴 분석</span>
-      <span class="home-pill">개인화 추천</span>
-      <span class="home-pill">시술 전 확인</span>
+      <span class="home-pill">취향 입력</span>
+      <span class="home-pill">얼굴 특징 분석</span>
+      <span class="home-pill">스타일 후보 추천</span>
+      <span class="home-pill">이력·트렌드 참고</span>
     </div>
 
     <div class="home-signal-grid">
       <article class="home-signal-card">
-        <strong>시술 전 방향 확인</strong>
-        <span>자르기 전에 어떤 스타일이 어울릴지 먼저 확인해 결과에 대한 불안을 줄입니다.</span>
+        <strong>상담 준비 시간 단축</strong>
+        <span>취향과 얼굴 특징을 미리 정리해 디자이너가 바로 상담 포인트를 잡을 수 있습니다.</span>
       </article>
       <article class="home-signal-card">
-        <strong>기대 차이 감소</strong>
-        <span>원하는 느낌과 실제 결과 사이의 오차를 줄일 수 있도록 추천 근거를 먼저 정리합니다.</span>
+        <strong>선택 기준 명확화</strong>
+        <span>왜 어울리는지, 어떤 점을 조정하면 좋은지 추천 근거를 함께 제공합니다.</span>
       </article>
       <article class="home-signal-card">
-        <strong>트렌드와 히스토리 연결</strong>
-        <span>최신 피드와 기존 추천 이력을 함께 보며 다음 선택의 방향을 더 안정적으로 잡습니다.</span>
+        <strong>재방문 상담 연결</strong>
+        <span>이전 추천과 최신 트렌드를 함께 확인해 다음 스타일 제안까지 이어갑니다.</span>
       </article>
     </div>
   </div>
@@ -71,7 +71,7 @@
       <div class="home-preview-head">
         <div>
           <p class="brand-sub home-preview-kicker">Salon Workflow</p>
-          <h3 class="home-preview-title">시술 전에 먼저 보는 4단계 흐름</h3>
+          <h3 class="home-preview-title">상담까지 이어지는 4단계 흐름</h3>
         </div>
         <span class="home-preview-status">Live Fit</span>
       </div>
@@ -79,34 +79,34 @@
       <div class="home-preview-grid">
         <article class="home-preview-step">
           <span class="home-preview-step-number">01</span>
-          <h4>고객 정보 입력</h4>
-          <p>이름, 연락처, 기본 정보를 먼저 정리합니다.</p>
+          <h4>고객 정보 등록</h4>
+          <p>기본 정보를 입력해 상담 기록의 기준을 만듭니다.</p>
         </article>
         <article class="home-preview-step">
           <span class="home-preview-step-number">02</span>
-          <h4>스타일 방향 정리</h4>
-          <p>원하는 길이와 분위기를 입력해 결과 방향을 먼저 좁힙니다.</p>
+          <h4>취향 설문 선택</h4>
+          <p>희망 길이와 분위기를 골라 원하는 이미지를 구체화합니다.</p>
         </article>
         <article class="home-preview-step">
           <span class="home-preview-step-number">03</span>
           <h4>얼굴 촬영 및 분석</h4>
-          <p>얼굴형과 인상 포인트를 읽어 어울림 기준을 만듭니다.</p>
+          <p>얼굴형과 인상 포인트를 분석해 추천 기준을 세웁니다.</p>
         </article>
         <article class="home-preview-step">
           <span class="home-preview-step-number">04</span>
-          <h4>추천 결과 먼저 확인</h4>
-          <p>시술 전에 어울리는 후보를 미리 보고 선택 오차를 줄입니다.</p>
+          <h4>스타일 후보 확인</h4>
+          <p>추천 후보와 근거를 보고 상담 방향을 결정합니다.</p>
         </article>
       </div>
 
       <div class="home-preview-foot">
         <div class="home-preview-note">
           <span>Trend Feed</span>
-          <strong>최신 스타일 흐름 참고</strong>
+          <strong>최근 트렌드 참고</strong>
         </div>
         <div class="home-preview-note">
           <span>History Sync</span>
-          <strong>이전 추천 결과와 비교 확인</strong>
+          <strong>이전 상담 기록과 비교</strong>
         </div>
       </div>
     </div>
@@ -130,13 +130,14 @@
     display: grid;
     grid-template-columns: minmax(0, 1.08fr) minmax(340px, 0.92fr);
     gap: 32px;
-    align-items: stretch;
+    align-items: center;
   }
 
   .home-hero-copy {
     display: flex;
     flex-direction: column;
-    gap: 20px;
+    justify-content: center;
+    gap: 18px;
   }
 
   .home-kicker,
@@ -196,19 +197,20 @@
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 14px;
-    margin-top: 4px;
+    margin-top: 0;
   }
 
   .home-signal-card {
-    padding: 18px 18px 20px;
+    padding: 16px 18px 18px;
     border-radius: 22px;
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.09);
     backdrop-filter: blur(12px);
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    min-height: 140px;
+    justify-content: center;
+    gap: 8px;
+    min-height: 124px;
   }
 
   .home-signal-card strong {
@@ -261,7 +263,7 @@
     justify-content: space-between;
     gap: 16px;
     align-items: flex-start;
-    margin-bottom: 26px;
+    margin-bottom: 22px;
   }
 
   .home-preview-kicker {
@@ -303,11 +305,11 @@
 
   .home-preview-step {
     position: relative;
-    padding: 18px;
+    padding: 16px;
     border-radius: 22px;
     background: rgba(17, 17, 17, 0.34);
     border: 1px solid rgba(255, 255, 255, 0.09);
-    min-height: 146px;
+    min-height: 132px;
   }
 
   .home-preview-step-number {
@@ -322,7 +324,7 @@
     color: var(--accent-neon);
     font-size: 15px;
     font-weight: 800;
-    margin-bottom: 18px;
+    margin-bottom: 14px;
   }
 
   .home-preview-step h4 {
@@ -387,7 +389,7 @@
     display: flex;
     justify-content: space-between;
     gap: 20px;
-    align-items: flex-end;
+    align-items: flex-start;
     flex-wrap: wrap;
   }
 
@@ -396,7 +398,8 @@
   }
 
   .home-section-head .section-copy {
-    max-width: 680px;
+    max-width: 620px;
+    padding-top: 28px;
   }
 
   .home-flow-grid {
@@ -408,11 +411,11 @@
   .home-flow-card {
     position: relative;
     overflow: hidden;
-    padding: 28px;
+    padding: 24px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    min-height: 238px;
+    gap: 14px;
+    min-height: 214px;
   }
 
   .home-flow-card::after {
@@ -467,7 +470,7 @@
   .home-story-panel {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 16px;
     min-height: 100%;
   }
 
@@ -549,10 +552,10 @@
   }
 
   .home-card {
-    padding: 28px;
+    padding: 24px;
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 14px;
     min-height: 100%;
     transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
   }
@@ -629,7 +632,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    margin-top: 4px;
+    margin-top: 0;
   }
 
   .home-card-tags span {
@@ -663,7 +666,7 @@
     gap: 24px;
     align-items: center;
     flex-wrap: wrap;
-    padding: 32px;
+    padding: 28px 32px;
     background:
       radial-gradient(circle at top right, rgba(245, 209, 13, 0.18), transparent 30%),
       linear-gradient(180deg, #151515 0%, #101010 100%);
@@ -676,7 +679,7 @@
   }
 
   .home-cta-panel .section-copy {
-    max-width: 680px;
+    max-width: 620px;
     color: rgba(255, 255, 255, 0.72);
   }
 
@@ -742,6 +745,10 @@
       flex-direction: column;
     }
 
+    .home-section-head .section-copy {
+      padding-top: 0;
+    }
+
     .home-preview-status {
       align-self: flex-start;
     }
@@ -788,40 +795,40 @@
     <div class="home-section-head">
       <div>
         <p class="home-section-kicker">Service Flow</p>
-        <h3 class="section-title">현재 제품 구조를 그대로 살린 시술 전 확인 플로우</h3>
+        <h3 class="section-title">고객 상담으로 자연스럽게 이어지는 추천 플로우</h3>
       </div>
       <p class="section-copy">
-        고객 정보 입력, 취향 정리, 얼굴 분석, 추천 결과 확인 구조를 유지하면서 시술 전에 결과 방향을 먼저 보여주는 서비스 성격이 드러나도록 정리했습니다.
+        기본 정보, 취향 설문, 얼굴 분석, 추천 결과까지 한 흐름으로 연결해 상담에 필요한 기준을 빠르게 정리합니다.
       </p>
     </div>
 
     <div class="home-flow-grid">
       <article class="panel home-flow-card">
         <span class="home-flow-step">01</span>
-        <h3 class="section-title">고객 정보 입력</h3>
-        <p class="section-copy">고객 기본 정보를 먼저 정리해 추천 결과를 생성할 기준을 안정적으로 맞춥니다.</p>
-        <span class="home-flow-note">추천 기준 정리</span>
+        <h3 class="section-title">고객 정보 등록</h3>
+        <p class="section-copy">이름, 연락처, 연령 등 기본 정보를 기록해 상담 이력과 추천 결과를 연결합니다.</p>
+        <span class="home-flow-note">상담 기준 생성</span>
       </article>
 
       <article class="panel home-flow-card">
         <span class="home-flow-step">02</span>
-        <h3 class="section-title">스타일 방향 정리</h3>
-        <p class="section-copy">길이, 분위기, 모발 상태 같은 선택지를 통해 막연한 요청을 시술 전 확인 가능한 방향으로 구체화합니다.</p>
-        <span class="home-flow-note">기대 이미지 정리</span>
+        <h3 class="section-title">취향 설문</h3>
+        <p class="section-copy">길이, 분위기, 모발 상태를 선택해 고객이 원하는 이미지를 구체적인 조건으로 바꿉니다.</p>
+        <span class="home-flow-note">희망 이미지 정리</span>
       </article>
 
       <article class="panel home-flow-card">
         <span class="home-flow-step">03</span>
         <h3 class="section-title">AI 얼굴 분석</h3>
-        <p class="section-copy">촬영 이미지를 바탕으로 얼굴형과 인상 포인트를 읽고, 어울림 판단의 기준을 만듭니다.</p>
-        <span class="home-flow-note">어울림 분석</span>
+        <p class="section-copy">촬영 이미지를 바탕으로 얼굴형과 인상 포인트를 읽고 스타일 매칭 기준을 만듭니다.</p>
+        <span class="home-flow-note">매칭 기준 분석</span>
       </article>
 
       <article class="panel home-flow-card">
         <span class="home-flow-step">04</span>
-        <h3 class="section-title">추천 결과 확인</h3>
-        <p class="section-copy">시술 전에 어울리는 스타일 후보를 먼저 확인해 결과물에 대한 불확실성을 줄입니다.</p>
-        <span class="home-flow-note">미리 보기 역할</span>
+        <h3 class="section-title">스타일 후보 확인</h3>
+        <p class="section-copy">추천 스타일과 근거를 함께 보여줘 고객과 디자이너가 같은 기준으로 상담할 수 있습니다.</p>
+        <span class="home-flow-note">후보 비교</span>
       </article>
     </div>
   </section>
@@ -829,46 +836,46 @@
   <section class="home-story-grid">
     <article class="panel home-story-panel home-story-panel--dark">
       <p class="home-section-kicker">Why MirrAI</p>
-      <h3 class="section-title">고객이 시술 전에 결과 방향을 먼저 확인할 수 있게 합니다</h3>
+      <h3 class="section-title">상담 기준을 눈에 보이게 만드는 헤어 추천 도구</h3>
       <p class="section-copy">
-        헤어 시술은 결과를 되돌리기 어렵고 미리 확인하기도 어렵기 때문에, MirrAI는 시술 전에 어울리는 방향을 먼저 보여주는 데 초점을 둡니다.
+        말로만 설명하기 어려운 취향과 이미지 변화를 데이터와 추천 후보로 정리해 고객 상담의 출발점을 선명하게 만듭니다.
       </p>
 
       <div class="home-point-list">
         <div class="home-point">
-          <strong>시술 전 불안을 줄입니다</strong>
-          <span>자르고 난 뒤를 상상만 하던 과정을 추천 결과로 먼저 확인할 수 있어 선택 부담을 낮춥니다.</span>
+          <strong>상담 대화를 빠르게 시작합니다</strong>
+          <span>고객의 취향, 얼굴 특징, 관심 스타일을 한 번에 확인해 첫 상담 시간을 줄입니다.</span>
         </div>
         <div class="home-point">
-          <strong>기대와 결과 차이를 줄입니다</strong>
-          <span>원하는 느낌을 입력값과 추천 결과로 정리해 고객과 디자이너가 같은 방향을 보게 만듭니다.</span>
+          <strong>추천 근거를 함께 남깁니다</strong>
+          <span>단순 후보가 아니라 왜 어울리는지 설명해 고객이 선택할 기준을 얻습니다.</span>
         </div>
         <div class="home-point">
-          <strong>다음 선택까지 이어집니다</strong>
-          <span>과거 추천 결과와 최신 트렌드를 함께 보며 재방문 시에도 방향성을 안정적으로 이어갈 수 있습니다.</span>
+          <strong>다음 방문에도 이어집니다</strong>
+          <span>이전 추천과 트렌드 기록을 남겨 재방문 때도 스타일 흐름을 쉽게 비교합니다.</span>
         </div>
       </div>
     </article>
 
     <article class="panel home-story-panel">
       <p class="home-section-kicker">When It Helps</p>
-      <h3 class="section-title">특히 결과가 불안한 순간에 먼저 확인하는 용도로 유용합니다</h3>
+      <h3 class="section-title">변화 폭이 클수록 기준 잡기에 도움이 됩니다</h3>
       <p class="section-copy">
-        큰 변화를 주는 시술일수록 결과를 미리 가늠하기 어려운 경우가 많습니다. MirrAI는 그런 순간에 방향을 먼저 확인하는 보조 역할에 맞춰집니다.
+        숏컷, 컬러 변화, 분위기 전환처럼 결정 전에 고민이 커지는 상황에서 고객의 선택지를 좁혀줍니다.
       </p>
 
       <div class="home-principle-list">
         <div class="home-principle">
           <strong>짧게 자르기 전</strong>
-          <span>숏컷, 단발처럼 변화 폭이 큰 스타일을 시도하기 전에 전체 인상 변화를 먼저 가늠할 수 있습니다.</span>
+          <span>숏컷이나 단발처럼 인상이 크게 바뀌는 스타일을 시도할 때 참고할 후보를 제공합니다.</span>
         </div>
         <div class="home-principle">
           <strong>이미지 변화를 크게 줄 때</strong>
-          <span>분위기 전환이 필요한 경우, 원하는 느낌이 실제로 어울리는 방향인지 먼저 좁혀볼 수 있습니다.</span>
+          <span>분위기 전환에 맞는 길이와 컬러 방향을 비교해 고객의 기대치를 구체화합니다.</span>
         </div>
         <div class="home-principle">
-          <strong>재방문 때 비교할 때</strong>
-          <span>이전 추천 결과와 이번 추천을 함께 보면서 다음 스타일 방향을 더 안정적으로 선택할 수 있습니다.</span>
+          <strong>재방문 상담을 이어갈 때</strong>
+          <span>이전 추천과 현재 취향을 함께 보며 다음 스타일 제안을 더 쉽게 조정합니다.</span>
         </div>
       </div>
     </article>
@@ -879,20 +886,20 @@
       <div>
         <p class="home-section-kicker">Quick Entry</p>
         {% if request.session.customer_id %}
-        <h3 class="section-title">지금 바로 이어서 진행할 수 있는 메뉴</h3>
+        <h3 class="section-title">바로 이어서 사용할 메뉴</h3>
         {% elif request.session.admin_id or request.session.designer_id %}
-        <h3 class="section-title">시술 전 확인에 바로 연결되는 주요 기능</h3>
+        <h3 class="section-title">상담 준비에 필요한 주요 기능</h3>
         {% else %}
-        <h3 class="section-title">MirrAI를 구성하는 핵심 기능</h3>
+        <h3 class="section-title">MirrAI 주요 기능</h3>
         {% endif %}
       </div>
 
       {% if request.session.customer_id %}
-      <p class="section-copy">이전 추천 확인, 최신 트렌드 탐색, 새로운 스타일 추천 시작까지 한 번에 이어갈 수 있습니다.</p>
+      <p class="section-copy">이전 기록 확인, 트렌드 탐색, 새 촬영까지 현재 상담 흐름에 맞게 바로 이동할 수 있습니다.</p>
       {% elif request.session.admin_id or request.session.designer_id %}
-      <p class="section-copy">시술 전에 결과 방향을 확인하는 데 필요한 분석, 추천, 이력, 트렌드 흐름을 메인에서 바로 이해할 수 있도록 정리했습니다.</p>
+      <p class="section-copy">분석, 추천, 이력, 트렌드 기능을 한 화면에서 살펴보고 고객 플로우로 연결합니다.</p>
       {% else %}
-      <p class="section-copy">첫 방문 사용자가 결과를 미리 확인하기 어려운 헤어 서비스의 특성을 어떻게 보완하는지 바로 이해할 수 있도록 구성했습니다.</p>
+      <p class="section-copy">얼굴 분석과 취향 기반 추천, 이력 관리가 어떻게 상담 경험을 보완하는지 간단히 확인할 수 있습니다.</p>
       {% endif %}
     </div>
 
@@ -905,13 +912,13 @@
           </div>
           <p class="home-card-topline">History</p>
         </div>
-        <h3 class="section-title">과거의 추천 내역</h3>
-        <p class="section-copy">이전에 확인했던 추천 결과를 먼저 보고, 이번 선택의 방향을 다시 빠르게 잡을 수 있습니다.</p>
+        <h3 class="section-title">추천 이력</h3>
+        <p class="section-copy">이전에 받은 스타일 후보를 확인하고 이번 상담의 비교 기준으로 활용합니다.</p>
         <div class="home-card-tags">
-          <span>추천 이력</span>
-          <span>비교 확인</span>
+          <span>이전 기록</span>
+          <span>비교 기준</span>
         </div>
-        <a href="{% url 'customer_history' %}" class="btn btn-dark">과거의 추천 내역 보기</a>
+        <a href="{% url 'customer_history' %}" class="btn btn-dark">추천 이력 보기</a>
       </article>
 
       <article class="panel home-card">
@@ -922,10 +929,10 @@
           <p class="home-card-topline">Trend</p>
         </div>
         <h3 class="section-title">최신 헤어 트렌드</h3>
-        <p class="section-copy">국내외 매거진과 수집 피드를 바탕으로 지금 주목받는 스타일 흐름과 컬러 방향을 빠르게 살펴볼 수 있습니다.</p>
+        <p class="section-copy">국내외 매거진과 수집 피드를 바탕으로 최근 스타일과 컬러 흐름을 살펴봅니다.</p>
         <div class="home-card-tags">
           <span>트렌드 피드</span>
-          <span>스타일 참고</span>
+          <span>컬러 참고</span>
         </div>
         <a href="{% url 'customer_trend' %}" class="btn btn-dark">트렌드 보기</a>
       </article>
@@ -938,10 +945,10 @@
           <p class="home-card-topline">New</p>
         </div>
         <h3 class="section-title">새로운 스타일 추천</h3>
-        <p class="section-copy">사진 촬영부터 다시 시작해, 지금 상태와 취향을 기준으로 시술 전에 새로운 추천 결과를 다시 확인할 수 있습니다.</p>
+        <p class="section-copy">새 사진과 현재 취향을 기준으로 이번 상담에 맞는 스타일 후보를 다시 생성합니다.</p>
         <div class="home-card-tags">
-          <span>새 분석</span>
-          <span>즉시 시작</span>
+          <span>새 촬영</span>
+          <span>추천 생성</span>
         </div>
         <a href="{% url 'customer_camera' %}" class="btn btn-primary" data-loading-cta="true" data-loading-label="분석 준비 중...">촬영 시작</a>
       </article>
@@ -956,7 +963,7 @@
           <p class="home-card-topline">Analysis</p>
         </div>
         <h3 class="section-title">AI 정밀 분석</h3>
-        <p class="section-copy">촬영 이미지와 고객 입력값을 바탕으로 시술 전 확인의 기준이 되는 분석 정보를 빠르게 확보합니다.</p>
+        <p class="section-copy">촬영 이미지와 고객 입력값을 함께 읽어 스타일 매칭에 필요한 기준을 확보합니다.</p>
         <div class="home-card-tags">
           <span>얼굴 분석</span>
           <span>어울림 기준</span>
@@ -970,8 +977,8 @@
           </div>
           <p class="home-card-topline">Personalized</p>
         </div>
-        <h3 class="section-title">개인화 추천</h3>
-        <p class="section-copy">얼굴형과 취향 입력을 함께 읽어, 고객의 고유한 인상과 니즈에 맞는 스타일 후보를 먼저 보여줍니다.</p>
+        <h3 class="section-title">맞춤 스타일 추천</h3>
+        <p class="section-copy">얼굴형, 취향, 분위기 선택을 바탕으로 고객에게 어울릴 후보를 추려냅니다.</p>
         <div class="home-card-tags">
           <span>취향 반영</span>
           <span>추천 근거</span>
@@ -985,8 +992,8 @@
           </div>
           <p class="home-card-topline">History</p>
         </div>
-        <h3 class="section-title">스마트 히스토리</h3>
-        <p class="section-copy">과거 추천 결과를 이어 보며 재방문 고객도 이전 선택과 현재 방향을 더 쉽게 비교할 수 있습니다.</p>
+        <h3 class="section-title">상담 히스토리</h3>
+        <p class="section-copy">이전 추천과 현재 상담 내용을 이어 보며 재방문 고객의 변화를 비교합니다.</p>
         <div class="home-card-tags">
           <span>재방문 비교</span>
           <span>기록 연결</span>
@@ -1001,7 +1008,7 @@
           <p class="home-card-topline">Trend</p>
         </div>
         <h3 class="section-title">최신 헤어 트렌드</h3>
-        <p class="section-copy">매거진과 수집 피드를 한곳에서 확인하며, 추천 결과와 함께 참고할 최신 스타일 흐름을 빠르게 찾습니다.</p>
+        <p class="section-copy">수집 피드와 매거진 정보를 참고해 상담 중 제안할 스타일 아이디어를 넓힙니다.</p>
         <div class="home-card-tags">
           <span>최신 흐름</span>
           <span>스타일 참고</span>
@@ -1019,7 +1026,7 @@
           <p class="home-card-topline">Analysis</p>
         </div>
         <h3 class="section-title">AI 정밀 분석</h3>
-        <p class="section-copy">고객의 얼굴형과 인상 포인트를 빠르게 읽어 시술 전에 확인할 추천 결과의 기준을 세웁니다.</p>
+        <p class="section-copy">얼굴형과 인상 포인트를 분석해 추천 후보를 만들 기준을 세웁니다.</p>
         <div class="home-card-tags">
           <span>얼굴 분석</span>
           <span>어울림 기준</span>
@@ -1033,7 +1040,7 @@
           </div>
           <p class="home-card-topline">Personalized</p>
         </div>
-        <h3 class="section-title">개인화 추천</h3>
+        <h3 class="section-title">맞춤 스타일 추천</h3>
         <p class="section-copy">취향 설문과 얼굴 분석을 결합해, 단순한 유행이 아니라 고객에게 어울리는 후보를 추려냅니다.</p>
         <div class="home-card-tags">
           <span>취향 반영</span>
@@ -1048,8 +1055,8 @@
           </div>
           <p class="home-card-topline">History</p>
         </div>
-        <h3 class="section-title">스마트 히스토리</h3>
-        <p class="section-copy">추천 결과를 축적해 재방문 시에도 이전 선택과 현재 방향을 자연스럽게 이어서 비교할 수 있습니다.</p>
+        <h3 class="section-title">상담 히스토리</h3>
+        <p class="section-copy">추천 결과를 축적해 재방문 때 이전 선택과 현재 취향을 비교할 수 있습니다.</p>
         <div class="home-card-tags">
           <span>비교 연속성</span>
           <span>기록 관리</span>
@@ -1062,13 +1069,13 @@
   <section class="panel home-cta-panel">
     <div>
       <p class="home-section-kicker">Start Now</p>
-      <h3 class="section-title">시술 전에 결과를 먼저 확인할 준비가 되었다면, 다음 단계로 이어가면 됩니다</h3>
+      <h3 class="section-title">고객 상담을 시작할 준비가 되면 바로 이동하세요</h3>
       {% if request.session.customer_id %}
-      <p class="section-copy">새 추천을 시작하거나, 이전 결과를 먼저 보고 지금 고객에게 맞는 방향을 다시 정리해 보세요.</p>
+      <p class="section-copy">새 추천을 만들거나, 기존 이력과 트렌드를 참고해 이번 선택을 정리할 수 있습니다.</p>
       {% elif request.session.admin_id or request.session.designer_id %}
-      <p class="section-copy">고객이 시술 전에 결과 방향을 확인하는 흐름을 메인에서 정리한 만큼, 이제 실제 고객 플로우로 바로 이동할 수 있습니다.</p>
+      <p class="section-copy">고객 정보 입력부터 촬영과 추천까지 실제 상담 플로우로 바로 이어집니다.</p>
       {% else %}
-      <p class="section-copy">고객 분석 시작과 파트너 진입을 분리해 두어, 방문 목적에 따라 가장 빠르게 결과 확인 흐름으로 이동할 수 있습니다.</p>
+      <p class="section-copy">파트너 로그인 후 고객 분석을 시작하거나, 파트너 센터에서 매장용 기능을 확인할 수 있습니다.</p>
       {% endif %}
     </div>
 


### PR DESCRIPTION

## 개요

index 페이지의 전체 구조는 유지하면서, 어색하거나 반복되던 문구를 상담 흐름에 맞게 자연스럽게 정리했습니다. 문구가 짧아진 부분은 기존 여백과 카드 높이에 맞지 않아 보일 수 있어, 관련 UI 간격과 정렬도 함께 조정했습니다.

## 변경 사항

- Hero 영역의 문구를 고객 상담과 스타일 후보 확인 중심으로 정리했습니다.
- `시술 전`, `먼저 확인`, `결과 방향`처럼 반복되던 표현을 줄이고, 섹션별 역할이 겹치지 않도록 문장을 재구성했습니다.
- 4단계 미리보기, 서비스 플로우, 주요 기능 카드, CTA 영역의 문구를 통일된 톤으로 다듬었습니다.
- 짧아진 문구에 맞춰 hero, 요약 카드, preview step, flow card, CTA 패널의 `gap`, `padding`, `min-height`, 정렬 값을 조정했습니다.

## 사용자 영향

- 첫 화면에서 MirrAI의 역할이 더 명확하게 전달됩니다.
- 고객, 디자이너, 관리자, 비로그인 사용자가 보는 index 문구의 톤이 더 일관됩니다.
- 짧아진 문장 때문에 생기던 과한 여백과 어색한 세로 위치가 완화됩니다.

## 기술적 영향

- 변경 범위는 `templates/index.html` 한 파일입니다.
- URL, 세션 분기, 버튼 이동 경로, 백엔드 로직은 변경하지 않았습니다.
- 기존 레이아웃 구조는 유지하고, 문구와 해당 문구에 맞는 CSS 보정만 적용했습니다.
