### PR TITLE
feat: 고객 히스토리 상담 완료 UX 개선 및 관리자 화면 업데이트

### DIFF
--- a/app/front_views.py
+++ b/app/front_views.py
@@ -496,12 +496,20 @@ def client_recommendation_history_page(request):
     if not client:
         return redirect("customer_index")
     payload = get_former_recommendations(client)
+    history_items = payload.get("items", [])
+    history_has_completed = any(bool(item.get("is_chosen")) for item in history_items if isinstance(item, dict))
+    latest_completed_item = next(
+        (item for item in history_items if isinstance(item, dict) and item.get("is_chosen")),
+        None,
+    )
     return render(
         request,
         "customer/history.html",
         {
             "client": client,
-            "history_items": payload.get("items", []),
+            "history_items": history_items,
+            "history_has_completed": history_has_completed,
+            "latest_completed_item": latest_completed_item,
             "history_message": payload.get("message"),
             "popup_message": _popup_message_from_notice(request.GET.get("notice")),
         },

--- a/app/services/runtime_cache.py
+++ b/app/services/runtime_cache.py
@@ -159,10 +159,13 @@ def invalidate_partner_client_cache(*, client=None, admin=None, designer=None) -
     resolved_designer = designer or getattr(client, "designer", None)
 
     scopes = set()
+    scopes.add(_scope_identity(admin=admin, designer=designer))
     if resolved_admin is not None:
         scopes.add(_scope_identity(admin=resolved_admin, designer=None))
     if resolved_admin is not None and resolved_designer is not None:
         scopes.add(_scope_identity(admin=resolved_admin, designer=resolved_designer))
+    if resolved_designer is not None:
+        scopes.add(_scope_identity(admin=None, designer=resolved_designer))
 
     for scope_identity in scopes:
         _bump_version(_version_key("scope", scope_identity))

--- a/templates/admin/customer_detail.html
+++ b/templates/admin/customer_detail.html
@@ -707,6 +707,7 @@
     const diagnosisApiUrl = `/api/v1/customers/${clientId}/diagnosis-card/`;
     const customerNoteApiUrl = `/api/v1/customers/${clientId}/customer-note/`;
     const consultationCloseApiUrl = `/api/v1/customers/${clientId}/consultation-close/`;
+    const dashboardRefreshFlagKey = 'partner-dashboard:refresh-required';
 
     let currentCustomer = null;
     let latestRetryPreviewHtml = '';
@@ -1822,6 +1823,11 @@
 
       applyClosedConsultationState();
       showDetailNotice(data.message || '상담 세션을 종료했습니다.', 'success');
+      try {
+        window.sessionStorage.setItem(dashboardRefreshFlagKey, String(Date.now()));
+      } catch (error) {
+        console.warn('Failed to set dashboard refresh flag:', error);
+      }
       window.setTimeout(() => {
         loadCustomerDetail().catch(() => null);
       }, 250);

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -378,6 +378,7 @@
     const DASHBOARD_CUSTOMERS_CACHE_KEY = `${DASHBOARD_SCOPE}:customers`;
     const DASHBOARD_DESIGNERS_CACHE_KEY = `${DASHBOARD_SCOPE}:designers`;
     const DASHBOARD_REPORT_CACHE_KEY_BASE = `${DASHBOARD_SCOPE}:trend-report`;
+    const DASHBOARD_REFRESH_REQUIRED_KEY = 'partner-dashboard:refresh-required';
     let chartJsPromise = null;
     const trendReportRequestMap = new Map();
     let activeReportType = 'styleTop10';
@@ -419,6 +420,39 @@
         }));
       } catch (error) {
         console.warn('Failed to cache dashboard payload:', error);
+      }
+    }
+
+    function consumeDashboardRefreshRequiredFlag() {
+      try {
+        const value = window.sessionStorage.getItem(DASHBOARD_REFRESH_REQUIRED_KEY);
+        if (!value) return false;
+        window.sessionStorage.removeItem(DASHBOARD_REFRESH_REQUIRED_KEY);
+        return true;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    function clearDashboardScopeCaches() {
+      try {
+        const keysToRemove = [];
+        for (let index = 0; index < window.sessionStorage.length; index += 1) {
+          const key = window.sessionStorage.key(index);
+          if (!key) continue;
+          if (
+            key === DASHBOARD_CUSTOMERS_CACHE_KEY
+            || key === DASHBOARD_DESIGNERS_CACHE_KEY
+            || key.startsWith(`${DASHBOARD_REPORT_CACHE_KEY_BASE}:`)
+          ) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((key) => {
+          window.sessionStorage.removeItem(key);
+        });
+      } catch (error) {
+        console.warn('Failed to clear dashboard cache:', error);
       }
     }
 
@@ -1259,8 +1293,12 @@
 
     document.addEventListener('DOMContentLoaded', () => {
       if (isDashboard) {
-        fetchDashboardDesigners();
-        fetchCustomers();
+        const needsRefresh = consumeDashboardRefreshRequiredFlag();
+        if (needsRefresh) {
+          clearDashboardScopeCaches();
+        }
+        fetchDashboardDesigners({ useCache: !needsRefresh, forceRefresh: needsRefresh });
+        fetchCustomers('', { useCache: !needsRefresh, forceRefresh: needsRefresh });
         if (window.requestIdleCallback) {
           window.requestIdleCallback(() => {
             loadChartJs().catch(() => {});

--- a/templates/customer/history.html
+++ b/templates/customer/history.html
@@ -33,6 +33,26 @@
     box-shadow: var(--shadow-neon);
   }
 
+  .history-card.recent-consultation {
+    border: 2px solid #ffb300;
+    box-shadow: 0 0 0 2px rgba(255, 179, 0, 0.2), var(--shadow-main);
+  }
+
+  .history-status-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 10px;
+    border-radius: 999px;
+    border: 1px solid #ffb300;
+    background: rgba(255, 179, 0, 0.12);
+    color: #8a4b00;
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 0.2px;
+    white-space: nowrap;
+  }
+
   .history-image-wrapper {
     position: relative;
     width: 100%;
@@ -99,16 +119,11 @@
 
 {% block content %}
 <div class="stack" style="gap: 24px; max-width: 1080px; margin: 0 auto;">
-  <div class="panel" style="padding: 28px;">
-    <h3 class="section-title" style="margin-bottom: 10px;">과거 해당 계정의 추천 내역</h3>
-    <p class="section-copy" style="margin-bottom: 0;">{{ history_message|default:"과거의 추천 내역을 확인할 수 있습니다." }}</p>
-  </div>
-
   {% if history_items %}
     <div id="historyGrid" class="history-grid">
       {% for item in history_items %}
         <article
-          class="history-card"
+          class="history-card {% if latest_completed_item and item.recommendation_id == latest_completed_item.recommendation_id %}recent-consultation{% endif %}"
           data-recommendation-id="{{ item.recommendation_id }}"
           data-style-name="{{ item.style_name|escape }}"
           data-match-score="{{ item.match_score|default:0 }}"
@@ -129,11 +144,15 @@
             <p class="section-copy" style="font-size: 13px;">{{ item.reasoning|default:item.style_description }}</p>
             <div style="display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; align-items: center;">
               <span style="font-size: 12px; color: var(--text-secondary);">{{ item.created_at|date:"Y-m-d H:i" }}</span>
-              {% if item.is_chosen %}
-                <span style="font-size: 12px; font-weight: 700; color: var(--accent-neon);">선택 완료</span>
+              {% if latest_completed_item and item.recommendation_id == latest_completed_item.recommendation_id %}
+                <span class="history-status-badge">최근 상담 완료</span>
+              {% elif item.is_chosen %}
+                <span class="history-status-badge">선택 완료</span>
               {% endif %}
             </div>
-            <button type="button" class="btn btn-dark history-select-btn" style="margin-top: auto; height: 44px;">선택하기</button>
+            {% if not history_has_completed %}
+              <button type="button" class="btn btn-dark history-select-btn" style="margin-top: auto; height: 44px;">선택하기</button>
+            {% endif %}
           </div>
         </article>
       {% endfor %}
@@ -145,11 +164,17 @@
   <div id="historySelectionBar" class="history-selection-bar {% if not history_items %}is-hidden{% endif %}">
     <div style="display: flex; flex-direction: column; gap: 4px;">
       <p style="font-size: 12px; color: rgba(255,255,255,0.55); font-weight: 600; text-transform: uppercase;">선택한 스타일</p>
-      <h4 id="selectedHistoryInfo" style="font-size: 18px; font-weight: 800; color: var(--accent-neon);">선택된 스타일이 없습니다.</h4>
+      {% if history_has_completed and latest_completed_item %}
+        <h4 id="selectedHistoryInfo" style="font-size: 18px; font-weight: 800; color: var(--accent-neon);">최근 상담 완료: {{ latest_completed_item.style_name }}</h4>
+      {% else %}
+        <h4 id="selectedHistoryInfo" style="font-size: 18px; font-weight: 800; color: var(--accent-neon);">선택된 스타일이 없습니다.</h4>
+      {% endif %}
     </div>
     <div class="history-actions">
       <a href="{% url 'customer_menu' %}" class="btn btn-dark" style="height: 48px; display: inline-flex; align-items: center; justify-content: center;">이전으로</a>
-      <button id="historyConsultBtn" type="button" class="btn btn-primary" style="height: 48px;" {% if not history_items %}disabled{% endif %}>이 스타일 선택(상담사 전송)</button>
+      {% if not history_has_completed %}
+        <button id="historyConsultBtn" type="button" class="btn btn-primary" style="height: 48px;" {% if not history_items %}disabled{% endif %}>이 스타일 선택(상담사 전송)</button>
+      {% endif %}
       <a href="{% url 'customer_camera' %}" class="btn btn-dark" style="height: 48px; display: inline-flex; align-items: center; justify-content: center;">새로운 스타일 추천(촬영)</a>
     </div>
   </div>
@@ -160,6 +185,7 @@
 <script>
   (function () {
     const customerId = "{{ request.session.customer_id|default:'' }}";
+    const historyHasCompleted = "{{ history_has_completed|yesno:'true,false' }}" === "true";
     const selectedInfo = document.getElementById("selectedHistoryInfo");
     const consultBtn = document.getElementById("historyConsultBtn");
     const cards = Array.from(document.querySelectorAll(".history-card"));
@@ -170,17 +196,26 @@
     };
 
     function setSelectedCard(card) {
+      if (historyHasCompleted) {
+        return;
+      }
       cards.forEach((row) => row.classList.remove("selected"));
       card.classList.add("selected");
       selectedState.recommendationId = Number(card.dataset.recommendationId);
       selectedState.styleName = card.dataset.styleName || "선택한 스타일";
       selectedState.matchScore = card.dataset.matchScore || 0;
       selectedInfo.textContent = `${selectedState.styleName} · ${selectedState.matchScore}% 매칭`;
-      consultBtn.disabled = false;
+      if (consultBtn) {
+        consultBtn.disabled = false;
+      }
     }
 
     async function submitHistoryConsultation() {
       if (!selectedState.recommendationId || !customerId) {
+        return;
+      }
+
+      if (!consultBtn) {
         return;
       }
 
@@ -207,16 +242,20 @@
         window.location.href = "/customer/consultation/complete/";
       } catch (error) {
         alert(error.message || "상담 요청에 실패했습니다.");
-        consultBtn.disabled = false;
+        if (consultBtn) {
+          consultBtn.disabled = false;
+        }
       }
     }
 
     cards.forEach((card) => {
-      card.addEventListener("click", () => setSelectedCard(card));
-      card.querySelector(".history-select-btn")?.addEventListener("click", (event) => {
-        event.stopPropagation();
-        setSelectedCard(card);
-      });
+      if (!historyHasCompleted) {
+        card.addEventListener("click", () => setSelectedCard(card));
+        card.querySelector(".history-select-btn")?.addEventListener("click", (event) => {
+          event.stopPropagation();
+          setSelectedCard(card);
+        });
+      }
     });
 
     consultBtn?.addEventListener("click", submitHistoryConsultation);


### PR DESCRIPTION
# 작업 리뷰 (2026-04-22)

## 브랜치

- `design/ui-0422_am`

## 커밋

- `194cf95`
- 메시지: `feat: 고객 히스토리 상담 완료 UX 개선 및 관리자 화면 업데이트`

## 반영 파일

- `app/front_views.py`
- `app/services/runtime_cache.py`
- `templates/admin/customer_detail.html`
- `templates/admin/index.html`
- `templates/customer/history.html`

## 주요 작업 내용

- 고객 `/customer/history/` 화면에서 상담 완료 상태를 기반으로 UI 분기 처리.
- 최근 상담 완료 카드를 더 잘 식별할 수 있도록 테두리 강조 및 상태 배지 스타일 개선.
- 상태 텍스트 중복 노출을 정리하고, 최근 상담 완료 상태를 우선 노출하도록 조정.
- 상담 완료 상태에서 선택/전송 버튼 노출 및 동작을 제한해 UX 일관성 보완.
- 관리자 화면 관련 템플릿/캐시 로직 보완 반영.

## 비고

- 원격 푸시 완료: `origin/design/ui-0422_am`
- 원격 안내: 저장소 canonical URL이 `.../SKN22-Final-1Team-WEB.git`로 안내됨.