### PR TITLE
고객 및 파트너 UX 개선

### DIFF
--- a/templates/customer/result.html
+++ b/templates/customer/result.html
@@ -9,6 +9,7 @@
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     gap: 24px;
     margin-top: 32px;
+    padding-bottom: 176px;
   }
 
   .style-card {
@@ -21,6 +22,7 @@
     flex-direction: column;
     box-shadow: var(--shadow-main);
     cursor: pointer;
+    position: relative;
   }
 
   .style-card:hover {
@@ -29,8 +31,23 @@
   }
 
   .style-card.selected {
-    border: 3px solid var(--accent-neon);
+    border-color: var(--accent-neon);
     box-shadow: var(--shadow-neon);
+  }
+
+  .style-card.selected::after {
+    content: "선택됨";
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    padding: 6px 10px;
+    border-radius: var(--radius-pill);
+    background: var(--bg-dark);
+    color: var(--accent-neon);
+    font-size: 11px;
+    font-weight: 900;
+    letter-spacing: 0;
+    z-index: 2;
   }
 
   .style-image-wrapper {
@@ -67,24 +84,69 @@
   }
 
   .selection-bar {
-    position: sticky;
-    bottom: 32px;
-    margin-top: 40px;
+    position: fixed;
+    left: 50%;
+    bottom: calc(20px + env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    width: min(1080px, calc(100% - 32px));
     background: var(--bg-dark);
     color: white;
-    padding: 20px 24px;
-    border-radius: var(--radius-lg);
-    z-index: 100;
-    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
-    display: flex;
-    flex-direction: column;
+    padding: 16px;
+    border-radius: 24px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    z-index: 900;
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.35);
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) auto;
+    align-items: center;
     gap: 16px;
+  }
+
+  .selection-copy {
+    min-width: 0;
+  }
+
+  .selection-label {
+    margin: 0 0 4px;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.55);
+    font-weight: 700;
+  }
+
+  .selection-title {
+    margin: 0;
+    color: var(--accent-neon);
+    font-size: 18px;
+    font-weight: 900;
+    line-height: 1.25;
+  }
+
+  .selection-hint {
+    margin: 5px 0 0;
+    color: rgba(255, 255, 255, 0.68);
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.4;
   }
 
   .selection-actions {
     display: flex;
     gap: 12px;
     flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .selection-actions .btn {
+    height: 48px;
+    padding: 0 22px;
+    white-space: nowrap;
+  }
+
+  .selection-actions .btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    transform: none;
+    box-shadow: none;
   }
 
   .loading-detail {
@@ -96,15 +158,18 @@
 
   #toast {
     position: fixed;
-    bottom: 40px;
+    bottom: calc(112px + env(safe-area-inset-bottom));
     left: 50%;
-    transform: translateX(-50%) translateY(100px);
+    transform: translateX(-50%) translateY(12px);
     background: var(--bg-dark);
     color: #ffffff;
     padding: 16px 32px;
     border-radius: var(--radius-pill);
     font-weight: 700;
-    transition: all 0.4s ease;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s ease;
     z-index: 1000;
     box-shadow: var(--shadow-neon);
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -112,6 +177,8 @@
 
   #toast.show {
     transform: translateX(-50%) translateY(0);
+    opacity: 1;
+    visibility: visible;
   }
 
   #toast[data-tone="success"] {
@@ -170,10 +237,32 @@
     .result-grid {
       grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
       gap: 16px;
+      padding-bottom: 240px;
+    }
+
+    .selection-bar {
+      bottom: calc(12px + env(safe-area-inset-bottom));
+      width: calc(100% - 24px);
+      grid-template-columns: 1fr;
+      padding: 14px;
+      border-radius: 20px;
     }
 
     .selection-actions {
-      flex-direction: column;
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 10px;
+    }
+
+    .selection-actions .btn {
+      width: 100%;
+      height: 46px;
+      padding: 0 14px;
+      font-size: 14px;
+    }
+
+    #toast {
+      bottom: calc(228px + env(safe-area-inset-bottom));
     }
   }
 </style>
@@ -237,22 +326,19 @@
 <div id="resultGrid" class="result-grid is-hidden"></div>
 
 <div id="selectionSummary" class="selection-bar is-hidden">
-  <div style="display: flex; flex-direction: column; gap: 4px;">
-    <p style="font-size: 12px; color: rgba(255,255,255,0.55); font-weight: 600;">선택한 스타일</p>
-    <h4 id="selectedInfo" style="font-size: 18px; font-weight: 800; color: var(--accent-neon);">스타일을 선택해 주세요.</h4>
+  <div class="selection-copy">
+    <p class="selection-label">선택한 스타일</p>
+    <h4 id="selectedInfo" class="selection-title">스타일을 선택해 주세요.</h4>
+    <p id="selectionHint" class="selection-hint">마음에 드는 카드를 누르면 바로 상담 요청 버튼이 활성화됩니다.</p>
   </div>
   <div class="selection-actions">
-    <button id="retryBtn" class="btn btn-dark"
-      style="height: 52px; padding: 0 24px; border: 1px solid rgba(255,255,255,0.2);">추천 다시 받기</button>
-    <button id="directConsultBtn" class="btn btn-dark"
-      style="height: 52px; padding: 0 24px; border: 1px solid rgba(255,255,255,0.2);">추천 없이 바로 상담 요청</button>
-    <button id="saveBtn" class="btn btn-primary"
-      style="height: 52px; padding: 0 40px; background: var(--accent-neon); color: var(--bg-dark); font-weight: 800;">선택한
-      스타일로 상담 요청</button>
+    <button id="retryBtn" class="btn btn-dark" style="border: 1px solid rgba(255,255,255,0.2);">추천 다시 받기</button>
+    <button id="directConsultBtn" class="btn btn-dark" style="border: 1px solid rgba(255,255,255,0.2);">추천 없이 상담 요청</button>
+    <button id="saveBtn" class="btn btn-primary" style="background: var(--accent-neon); color: var(--bg-dark); font-weight: 900;">스타일 선택 후 상담 요청</button>
   </div>
 </div>
 
-<div id="toast">상담 요청이 접수됐습니다.</div>
+<div id="toast"></div>
 {% endblock %}
 
 {% block page_scripts %}
@@ -272,6 +358,7 @@
     const loadingTitle = document.getElementById('loadingTitle');
     const loadingDetail = document.getElementById('loadingDetail');
     const toast = document.getElementById('toast');
+    const selectionHint = document.getElementById('selectionHint');
     let selectedStyleId = null;
     let retryMeta = null;
     let retryRequestInFlight = false;
@@ -388,6 +475,51 @@
       }
     }
 
+    function notifyUser(message, { tone = 'error', title = '' } = {}) {
+      if (window.showAppNotice) {
+        window.showAppNotice(message, {
+          tone,
+          title: title || (tone === 'error' ? '확인이 필요합니다' : '알림'),
+        });
+        return;
+      }
+
+      showToast(message, { tone });
+    }
+
+    function redirectWithNotice(message, targetUrl) {
+      notifyUser(message, { tone: 'error' });
+      window.setTimeout(() => {
+        window.location.href = targetUrl;
+      }, 800);
+    }
+
+    function syncSelectionUI() {
+      const hasSelection = Boolean(selectedStyleId);
+      const hasResults = Boolean(grid && grid.children && grid.children.length > 0);
+
+      if (saveBtn) {
+        saveBtn.disabled = retryRequestInFlight || !hasSelection;
+        if (hasSelection) {
+          saveBtn.textContent = '선택한 스타일로 상담 요청';
+        } else if (hasResults) {
+          saveBtn.textContent = '스타일 선택 후 상담 요청';
+        } else {
+          saveBtn.textContent = '추천 결과 없음';
+        }
+      }
+
+      if (selectionHint) {
+        if (hasSelection) {
+          selectionHint.textContent = '이 화면에서 바로 상담 요청할 수 있습니다.';
+        } else if (hasResults) {
+          selectionHint.textContent = '마음에 드는 카드를 누르면 바로 상담 요청 버튼이 활성화됩니다.';
+        } else {
+          selectionHint.textContent = '추천 결과 없이 바로 상담 요청을 보낼 수 있습니다.';
+        }
+      }
+    }
+
     function syncRetryPendingUI() {
       const busyTextBottom = '추천 재생성 중...';
       const busyTextTop = '재생성 중...';
@@ -416,11 +548,11 @@
           persist: true,
         });
       } else {
-        saveBtn.disabled = !selectedStyleId;
         directConsultBtn.disabled = false;
         hideToast();
       }
 
+      syncSelectionUI();
       syncRetryPendingUI();
       syncRetryButton();
     }
@@ -523,22 +655,22 @@
       loading.innerHTML = `<p class="section-title">${escapeHtml(message || '추천 결과가 아직 준비되지 않았습니다. 잠시 후 다시 확인해 주세요.')}</p>`;
       loading.classList.remove('is-hidden');
       selectionBar.classList.remove('is-hidden');
+      selectedStyleId = null;
       selectedInfo.textContent = '추천 결과 없이 바로 상담 요청도 가능합니다.';
+      syncSelectionUI();
       syncRetryButton();
     }
 
     async function fetchRecommendations({ polling = false } = {}) {
       if (!customerId) {
-        alert('세션 정보가 없습니다. 다시 시작해 주세요.');
-        window.location.href = '/customer/';
+        redirectWithNotice('세션 정보가 없습니다. 다시 시작해 주세요.', '/customer/');
         return;
       }
 
       try {
         const response = await fetch(`/api/v1/analysis/recommendations/?client_id=${customerId}`);
         if (response.status === 401 || response.status === 403) {
-          alert('세션이 만료되었습니다. 다시 시작해 주세요.');
-          window.location.href = '/customer/';
+          redirectWithNotice('세션이 만료되었습니다. 다시 시작해 주세요.', '/customer/');
           return;
         }
 
@@ -687,6 +819,7 @@
         retryTopBtn.style.opacity = (canRetry && !retryRequestInFlight) ? '1' : '0.55';
       }
       syncRetryPendingUI();
+      syncSelectionUI();
     }
 
     function selectStyle(style) {
@@ -710,10 +843,11 @@
         if (selectedCard) {
           selectedCard.classList.add('selected');
           const btn = selectedCard.querySelector('.select-btn');
-          if (btn) btn.textContent = '선택 해제';
+          if (btn) btn.textContent = '선택 완료';
         }
-        selectedInfo.innerHTML = `${style.style_name} <span style="color: var(--accent-neon); margin-left: 8px;">${style.match_score || 0}% Match</span>`;
+        selectedInfo.textContent = `${style.style_name || '추천 스타일'} · ${style.match_score || 0}% Match`;
       }
+      syncSelectionUI();
       syncRetryButton();
     }
 
@@ -753,15 +887,16 @@
       selectedStyleId = null;
       retryMeta = data;
       selectedInfo.textContent = '새 추천 결과를 확인해 주세요.';
+      syncSelectionUI();
       renderResults(data.items || []);
     }
 
     saveBtn.addEventListener('click', async () => {
       if (!selectedStyleId) {
         if (grid && grid.children.length > 0) {
-          alert('상담을 요청할 스타일을 선택해 주세요.\n마음에 드는 스타일 카드를 클릭하면 선택됩니다.');
+          notifyUser('상담을 요청할 스타일을 먼저 선택해 주세요.');
         } else {
-          alert('현재 추천된 스타일이 없습니다.\n"추천 없이 바로 상담 요청" 버튼을 이용해 주세요.');
+          notifyUser('현재 추천된 스타일이 없습니다. 추천 없이 상담 요청 버튼을 이용해 주세요.');
         }
         return;
       }
@@ -776,9 +911,10 @@
           source: 'current_recommendations'
         });
       } catch (error) {
-        alert(error.message);
+        notifyUser(error.message);
         saveBtn.disabled = false;
         directConsultBtn.disabled = false;
+        syncSelectionUI();
         syncRetryButton();
       }
     });
@@ -794,9 +930,10 @@
           direct_consultation: true
         });
       } catch (error) {
-        alert(error.message);
+        notifyUser(error.message);
         saveBtn.disabled = false;
         directConsultBtn.disabled = false;
+        syncSelectionUI();
         syncRetryButton();
       }
     });

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,7 +27,7 @@
       <a href="{% url 'partner_staff_dashboard' %}" class="btn btn-dark home-btn-ghost">디자이너 대시보드</a>
       {% else %}
       <a href="{% url 'partner_designer_select' %}?next={% url 'customer_index' %}" class="btn btn-primary" data-loading-cta="true" data-loading-label="고객 화면 준비 중...">고객 분석 시작</a>
-      <a href="{% url 'partner_dashboard' %}" class="btn btn-dark home-btn-ghost">파트너 센터</a>
+      <a href="{% url 'partner_dashboard' %}" class="btn btn-dark home-btn-ghost" data-admin-gate="true" data-admin-gate-scope="dashboard">파트너 센터</a>
       {% endif %}
     </div>
     {% else %}
@@ -1088,7 +1088,7 @@
       <a href="{% url 'partner_staff_dashboard' %}" class="btn btn-dark home-btn-ghost">대시보드 보기</a>
       {% elif request.session.admin_id %}
       <a href="{% url 'partner_designer_select' %}?next={% url 'customer_index' %}" class="btn btn-primary" data-loading-cta="true" data-loading-label="고객 화면 준비 중...">고객 분석 시작</a>
-      <a href="{% url 'partner_dashboard' %}" class="btn btn-dark home-btn-ghost">파트너 센터</a>
+      <a href="{% url 'partner_dashboard' %}" class="btn btn-dark home-btn-ghost" data-admin-gate="true" data-admin-gate-scope="dashboard">파트너 센터</a>
       {% else %}
       <a href="{% url 'partner_login' %}?next={% url 'partner_designer_select' %}?next={% url 'customer_index' %}" class="btn btn-primary" data-loading-cta="true" data-loading-label="로그인 화면 준비 중...">분석 시작하기</a>
       <a href="{% url 'partner_index' %}" class="btn btn-dark home-btn-ghost">파트너 센터</a>

--- a/templates/layouts/base_site.html
+++ b/templates/layouts/base_site.html
@@ -31,9 +31,9 @@
       /* 글로벌 관리자 전용 다크 키패드 모달 스타일 - admin-pin 변경 페이지와 동일한 디자인 */
       .keypad-overlay {
         position: fixed; top: 0; left: 0; width: 100%; height: 100%;
-        background: rgba(0, 0, 0, 0.85); backdrop-filter: blur(8px);
+        background: rgba(0, 0, 0, 0.88);
         display: none; align-items: center; justify-content: center; z-index: 10000;
-        opacity: 0; transition: all 0.3s ease;
+        opacity: 0; transition: opacity 0.18s ease;
       }
       .keypad-overlay.active { display: flex; opacity: 1; }
       .keypad-container {
@@ -41,22 +41,106 @@
         border-radius: 24px; padding: 32px; text-align: center;
         box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
       }
+      .keypad-container.is-shaking { animation: admin-pin-shake 0.32s ease; }
       .keypad-title { font-size: 18px; font-weight: 700; color: #fff; margin-bottom: 8px; }
       .keypad-subtitle { font-size: 13px; color: rgba(255, 255, 255, 0.5); margin-bottom: 24px; }
       .keypad-display { display: flex; justify-content: center; gap: 12px; margin-bottom: 32px; }
-      .keypad-dot { width: 16px; height: 16px; border-radius: 50%; background: rgba(255, 255, 255, 0.1); transition: all 0.2s ease; }
+      .keypad-dot { width: 16px; height: 16px; border-radius: 50%; background: rgba(255, 255, 255, 0.1); transition: background-color 0.12s ease, box-shadow 0.12s ease; }
       .keypad-dot.active { background: var(--accent-neon); box-shadow: 0 0 10px var(--accent-neon); }
       .keypad-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
       .keypad-btn {
         aspect-ratio: 1; border-radius: 50%; background: rgba(255, 255, 255, 0.05);
         border: 1px solid rgba(255, 255, 255, 0.1); color: #fff;
         font-size: 20px; font-weight: 600; cursor: pointer;
-        display: flex; align-items: center; justify-content: center; transition: all 0.15s ease;
+        display: flex; align-items: center; justify-content: center; transition: background-color 0.12s ease, transform 0.08s ease;
       }
       .keypad-btn:active { background: rgba(255, 255, 255, 0.2); transform: scale(0.92); }
       .keypad-btn.btn-empty { background: transparent; border: none; cursor: default; }
       .keypad-btn.btn-back { font-size: 14px; color: var(--status-red); }
       .keypad-close { margin-top: 24px; font-size: 14px; color: rgba(255, 255, 255, 0.4); background: none; border: none; cursor: pointer; text-decoration: underline; }
+
+      .app-notice-stack {
+        position: fixed;
+        top: 24px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 10100;
+        width: min(420px, calc(100% - 32px));
+        pointer-events: none;
+      }
+
+      .app-notice {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        padding: 14px 16px;
+        border-radius: 18px;
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(14, 19, 17, 0.96);
+        box-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+        color: #fff;
+        opacity: 0;
+        transform: translateY(-10px) scale(0.98);
+        transition: opacity 0.16s ease, transform 0.16s ease;
+      }
+
+      .app-notice.is-visible {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+
+      .app-notice-icon {
+        flex: 0 0 auto;
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(245, 209, 13, 0.16);
+        color: var(--accent-neon);
+        font-size: 16px;
+        font-weight: 900;
+        line-height: 1;
+      }
+
+      .app-notice[data-tone="error"] .app-notice-icon {
+        background: rgba(255, 91, 91, 0.14);
+        color: var(--status-red);
+      }
+
+      .app-notice[data-tone="success"] .app-notice-icon {
+        background: rgba(54, 211, 153, 0.14);
+        color: #36d399;
+      }
+
+      .app-notice-copy {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        min-width: 0;
+      }
+
+      .app-notice-title {
+        font-size: 13px;
+        font-weight: 800;
+        line-height: 1.25;
+      }
+
+      .app-notice-message {
+        color: rgba(255, 255, 255, 0.72);
+        font-size: 13px;
+        font-weight: 600;
+        line-height: 1.45;
+      }
+
+      @keyframes admin-pin-shake {
+        0%, 100% { transform: translateX(0); }
+        20% { transform: translateX(-8px); }
+        40% { transform: translateX(7px); }
+        60% { transform: translateX(-5px); }
+        80% { transform: translateX(4px); }
+      }
 
       /* 분석 시작하기 launcher: nav-link 형태의 버튼 (a 태그와 시각적으로 동일) */
       .nav-link-button {
@@ -209,13 +293,13 @@
             <nav class="nav-links">
               <a href="{% url 'index' %}" class="nav-link">메인</a>
               
-              {# 분석 시작하기 버튼 #}
+              {# 고객 플로우 진입 버튼 #}
               {% if request.session.customer_id %}
-                <button type="button" class="nav-link nav-link-button" data-analysis-launcher="true">분석 시작하기</button>
+                <button type="button" class="nav-link nav-link-button" data-analysis-launcher="true">새 추천</button>
               {% elif request.session.designer_id %}
-                <a href="{% url 'customer_index' %}" class="nav-link">분석 시작하기</a>
+                <a href="{% url 'customer_index' %}" class="nav-link">고객</a>
               {% elif request.session.admin_id %}
-                <a href="{% url 'partner_designer_select' %}?next={% url 'customer_index' %}" class="nav-link">분석 시작하기</a>
+                <a href="{% url 'partner_designer_select' %}?next={% url 'customer_index' %}" class="nav-link">고객</a>
               {% else %}
                 <a href="{% url 'partner_index' %}?next=/partner/designer-select/?next=/customer/" class="nav-link">분석 시작하기</a>
               {% endif %}
@@ -306,10 +390,76 @@
       {% include "components/footer.html" %}
     </div>
 
+    <div id="appNoticeStack" class="app-notice-stack" aria-live="polite" aria-atomic="true"></div>
+
+    <script>
+      (function() {
+        const noticeStack = document.getElementById('appNoticeStack');
+        let noticeTimer = null;
+
+        window.showAppNotice = function(message, options = {}) {
+          if (!message || !noticeStack) {
+            return;
+          }
+
+          const tone = options.tone || 'info';
+          const title = options.title || (tone === 'error' ? '확인이 필요합니다' : '알림');
+          const duration = Number(options.duration || 2600);
+          const iconText = tone === 'success' ? 'OK' : '!';
+
+          if (noticeTimer) {
+            clearTimeout(noticeTimer);
+            noticeTimer = null;
+          }
+
+          noticeStack.textContent = '';
+
+          const notice = document.createElement('div');
+          notice.className = 'app-notice';
+          notice.dataset.tone = tone;
+          notice.setAttribute('role', tone === 'error' ? 'alert' : 'status');
+
+          const icon = document.createElement('span');
+          icon.className = 'app-notice-icon';
+          icon.textContent = iconText;
+
+          const copy = document.createElement('span');
+          copy.className = 'app-notice-copy';
+
+          const titleEl = document.createElement('span');
+          titleEl.className = 'app-notice-title';
+          titleEl.textContent = title;
+
+          const messageEl = document.createElement('span');
+          messageEl.className = 'app-notice-message';
+          messageEl.textContent = message;
+
+          copy.appendChild(titleEl);
+          copy.appendChild(messageEl);
+          notice.appendChild(icon);
+          notice.appendChild(copy);
+          noticeStack.appendChild(notice);
+
+          requestAnimationFrame(function() {
+            notice.classList.add('is-visible');
+          });
+
+          noticeTimer = setTimeout(function() {
+            notice.classList.remove('is-visible');
+            notice.addEventListener('transitionend', function() {
+              if (notice.parentNode === noticeStack) {
+                noticeStack.removeChild(notice);
+              }
+            }, { once: true });
+          }, duration);
+        };
+      })();
+    </script>
+
     {% if popup_message %}
     <script>
       window.addEventListener('DOMContentLoaded', function () {
-        alert('{{ popup_message|escapejs }}');
+        window.showAppNotice('{{ popup_message|escapejs }}', { title: '알림', tone: 'info' });
       });
     </script>
     {% endif %}
@@ -515,8 +665,21 @@
         let pinTargetId = '';
         let pinTargetScope = 'dashboard';
         const pinModal = document.getElementById('adminPinModal');
+        const pinContainer = document.querySelector('#adminPinModal .keypad-container');
         const pinDots = document.querySelectorAll('#adminPinModal .keypad-dot');
         const pinSubtext = document.getElementById('pinModalSubtext');
+
+        const showAdminGateError = function(message) {
+          if (window.showAppNotice) {
+            window.showAppNotice(message, { title: '인증 실패', tone: 'error' });
+          }
+
+          if (pinContainer) {
+            pinContainer.classList.remove('is-shaking');
+            void pinContainer.offsetWidth;
+            pinContainer.classList.add('is-shaking');
+          }
+        };
 
         const submitAdminGatePin = async function() {
           if (!currentPin || currentPin.length < 4) return;
@@ -549,12 +712,12 @@
                 window.location.reload();
               }
             } else {
-              alert(data.message || '보안키가 일치하지 않습니다.');
+              showAdminGateError(data.message || '보안키가 일치하지 않습니다.');
               window.adminGateClearPin();
             }
           } catch (error) {
             console.error('PIN submit error:', error);
-            alert('인증 처리 중 오류가 발생했습니다.');
+            showAdminGateError('인증 처리 중 오류가 발생했습니다.');
             window.adminGateClearPin();
           }
         };


### PR DESCRIPTION
## 작업 내용

고객 추천 결과 페이지와 파트너 센터 진입 흐름의 UX를 개선했습니다.

### 고객 추천 결과 페이지

- `/customer/recommendations/`에서 스타일 선택 후 하단까지 스크롤해야 상담 요청할 수 있던 흐름을 개선했습니다.
- 선택/상담 요청 액션 바를 화면 하단 고정형으로 변경했습니다.
- 스타일 선택 전에는 `스타일 선택 후 상담 요청` 버튼이 비활성화되고, 선택 후 `선택한 스타일로 상담 요청`으로 즉시 활성화됩니다.
- 선택된 스타일 카드에 `선택됨` 배지를 표시해 선택 상태를 명확히 했습니다.
- `추천 없이 상담 요청` 버튼도 고정 액션 바에 배치했습니다.
- 추천 결과 페이지의 기본 `alert()`를 커스텀 알림으로 교체했습니다.
- 로딩 중 `상담 요청이 접수됐습니다.` 토스트가 너무 일찍 노출되던 문제를 수정했습니다.

### 파트너 센터 진입 UX

- index 페이지의 `파트너 센터` 버튼에서 서버 리다이렉트를 거치지 않고 현재 화면에서 바로 관리자 보안키 모달이 뜨도록 수정했습니다.
- 관리자 보안키 모달의 배경 blur와 과한 transition을 줄여 체감 렌더링 부담을 낮췄습니다.
- 보안키 오류 시 브라우저 기본 팝업 대신 전역 커스텀 알림과 키패드 흔들림 효과를 사용하도록 변경했습니다.

### 상단 네비게이션 문구

- 고객 세션: `새 추천`
- 관리자/디자이너 세션: `고객`
- 비로그인 상태: `분석 시작하기` 유지

## 변경 파일

- `templates/customer/result.html`
- `templates/index.html`
- `templates/layouts/base_site.html`

## 검증

- `git diff --check` 통과
- `templates/customer/result.html` 스크립트 `node --check` 통과
- `python manage.py check`는 로컬 환경에 `langchain_chroma` 패키지가 없어 실행 불가
