### PR TITLE
fix: use name+phone client matching and stabilize menu resume state

### DIFF
--- a/app/front_views.py
+++ b/app/front_views.py
@@ -529,8 +529,19 @@ def client_menu_page(request):
 
     survey = get_latest_survey(client)
     capture = get_latest_capture(client)
+    former_payload = get_former_recommendations(client)
+    former_items = former_payload.get("items", []) if isinstance(former_payload, dict) else []
+    has_completed_consultation = any(
+        bool(item.get("is_chosen"))
+        for item in former_items
+        if isinstance(item, dict)
+    )
 
-    if survey:
+    if has_completed_consultation:
+        resume_step = None
+        resume_step_label = None
+        resume_url = None
+    elif survey:
         resume_step = 3
         resume_step_label = "추천 결과 확인"
         resume_url = reverse("customer_result")
@@ -539,9 +550,9 @@ def client_menu_page(request):
         resume_step_label = "스타일 설문"
         resume_url = reverse("customer_survey")
     else:
-        resume_step = None
-        resume_step_label = None
-        resume_url = None
+        resume_step = 1
+        resume_step_label = "사진 촬영 / 업로드"
+        resume_url = reverse("customer_camera")
 
     return render(
         request,
@@ -552,6 +563,7 @@ def client_menu_page(request):
             "resume_step": resume_step,
             "resume_step_label": resume_step_label,
             "resume_url": resume_url,
+            "has_completed_consultation": has_completed_consultation,
         },
     )
 

--- a/app/services/model_team_bridge.py
+++ b/app/services/model_team_bridge.py
@@ -137,6 +137,10 @@ def _normalize_phone(value: str | None) -> str:
     return "".join(char for char in str(value or "") if char.isdigit())
 
 
+def _normalize_person_name(value: str | None) -> str:
+    return "".join(str(value or "").split()).casefold()
+
+
 @lru_cache(maxsize=None)
 def _table_columns(table_name: str) -> frozenset[str]:
     with connection.cursor() as cursor:
@@ -807,8 +811,14 @@ def upsert_client_record(*, phone: str, name: str, gender: str | None = None, ag
     if not _has_columns("client", LEGACY_CLIENT_MODEL_COLUMNS):
         raise RuntimeError("Legacy client table is required.")
     normalized_phone = _normalize_phone(phone)
+    normalized_name = _normalize_person_name(name)
     created_at = timezone.now()
-    row = LegacyClient.objects.filter(phone=normalized_phone).order_by("-backend_client_id", "client_id").first()
+    row = None
+    for candidate in LegacyClient.objects.filter(phone=normalized_phone).order_by("-backend_client_id", "client_id"):
+        candidate_name = _normalize_person_name(getattr(candidate, "name", None) or getattr(candidate, "client_name", None))
+        if candidate_name == normalized_name:
+            row = candidate
+            break
     if row is None:
         backend_client_id = _next_backend_ref_id(LegacyClient, "backend_client_id")
         legacy_client_id = str(_legacy_uuid("client", backend_client_id))


### PR DESCRIPTION
작업 리포트 (20260422_PM_v1)
브랜치: design/ui-0422_pm


작업 내용
고객 매칭 기준 개선

기존 전화번호 단독 매칭을 전화번호 + 이름 매칭으로 변경
동일 번호라도 이름이 다르면 신규 고객으로 생성되도록 보정
파일: app/services/model_team_bridge.py

메뉴 진행상태 노출 로직 보정

상담 완료 이력(is_chosen)이 있을 때 상단 진행 상태 블록 숨김 유지
신규/미완료 고객의 진행 상태 노출이 정상 동작하도록 분기 안정화
파일: app/front_views.py

변경 통계
2 files changed
27 insertions(+), 5 deletions(-)

검증
python manage.py check 통과