### PR TITLE
fix: align menu resume state and fully localize recommendation style …

### DIFF
--- a/app/front_views.py
+++ b/app/front_views.py
@@ -27,6 +27,7 @@ from app.services.model_team_bridge import (
     get_designers_for_admin,
     get_legacy_admin_id,
     get_legacy_designer_id,
+    has_legacy_chosen_consultation,
     update_designer_active_state,
     upsert_client_record,
 )
@@ -529,30 +530,42 @@ def client_menu_page(request):
 
     survey = get_latest_survey(client)
     capture = get_latest_capture(client)
-    former_payload = get_former_recommendations(client)
-    former_items = former_payload.get("items", []) if isinstance(former_payload, dict) else []
-    has_completed_consultation = any(
-        bool(item.get("is_chosen"))
-        for item in former_items
-        if isinstance(item, dict)
+    has_completed_consultation = has_legacy_chosen_consultation(client=client)
+
+    survey_at = getattr(survey, "created_at", None)
+    capture_at = (
+        getattr(capture, "updated_at", None)
+        or getattr(capture, "created_at", None)
+    )
+    if survey_at is not None and timezone.is_naive(survey_at):
+        survey_at = timezone.make_aware(survey_at, timezone.get_current_timezone())
+    if capture_at is not None and timezone.is_naive(capture_at):
+        capture_at = timezone.make_aware(capture_at, timezone.get_current_timezone())
+    needs_survey_after_capture = bool(
+        capture
+        and (
+            survey is None
+            or (survey_at is not None and capture_at is not None and survey_at < capture_at)
+        )
     )
 
     if has_completed_consultation:
         resume_step = None
         resume_step_label = None
         resume_url = None
+    elif needs_survey_after_capture:
+        resume_step = 2
+        resume_step_label = "스타일 설문"
+        resume_url = reverse("customer_survey")
     elif survey:
         resume_step = 3
         resume_step_label = "추천 결과 확인"
         resume_url = reverse("customer_result")
-    elif capture:
-        resume_step = 2
-        resume_step_label = "스타일 설문"
-        resume_url = reverse("customer_survey")
     else:
-        resume_step = 1
-        resume_step_label = "사진 촬영 / 업로드"
-        resume_url = reverse("customer_camera")
+        # 첫 방문(진행 이력 없음)은 진행 상태 UI를 숨긴다.
+        resume_step = None
+        resume_step_label = None
+        resume_url = None
 
     return render(
         request,

--- a/app/management/commands/audit_client_history_scope.py
+++ b/app/management/commands/audit_client_history_scope.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+from django.core.management.base import BaseCommand
+
+from app.models_model_team import LegacyClient, LegacyClientResult, LegacyClientResultDetail
+
+
+def _normalize_phone(value: str | None) -> str:
+    return "".join(char for char in str(value or "") if char.isdigit())
+
+
+def _normalize_name(value: str | None) -> str:
+    return "".join(str(value or "").split()).casefold()
+
+
+@dataclass
+class AuditStats:
+    client_count: int = 0
+    result_count: int = 0
+    detail_count: int = 0
+    duplicate_identity_group_count: int = 0
+    duplicate_identity_client_count: int = 0
+    orphan_result_count: int = 0
+    inconsistent_result_ref_count: int = 0
+    fix_result_backend_client_ref_count: int = 0
+    fix_result_legacy_client_ref_count: int = 0
+    fix_result_admin_scope_ref_count: int = 0
+    fix_detail_backend_client_ref_count: int = 0
+
+
+class Command(BaseCommand):
+    help = (
+        "Audit client/history scope consistency. "
+        "By default runs dry-run; pass --apply to persist safe reference fixes."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Apply safe fixes for result/detail client/admin reference mismatches.",
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            dest="as_json",
+            help="Print report as JSON.",
+        )
+
+    def handle(self, *args, **options):
+        apply_changes: bool = bool(options.get("apply"))
+        as_json: bool = bool(options.get("as_json"))
+
+        stats = AuditStats()
+        report: dict[str, object] = {"mode": "apply" if apply_changes else "dry-run"}
+
+        clients = list(
+            LegacyClient.objects.all().values(
+                "client_id",
+                "backend_client_id",
+                "shop_id",
+                "backend_shop_ref_id",
+                "name",
+                "client_name",
+                "phone",
+            )
+        )
+        stats.client_count = len(clients)
+
+        by_backend_client_id: dict[int, dict] = {}
+        by_legacy_client_id: dict[str, dict] = {}
+        identity_groups: dict[tuple[str, str], list[dict]] = {}
+
+        for row in clients:
+            backend_client_id = row.get("backend_client_id")
+            legacy_client_id = str(row.get("client_id") or "").strip()
+            if backend_client_id is not None:
+                by_backend_client_id[int(backend_client_id)] = row
+            if legacy_client_id:
+                by_legacy_client_id[legacy_client_id] = row
+
+            normalized_phone = _normalize_phone(row.get("phone"))
+            normalized_name = _normalize_name(row.get("name") or row.get("client_name"))
+            if normalized_phone and normalized_name:
+                identity_groups.setdefault((normalized_phone, normalized_name), []).append(row)
+
+        duplicate_groups_payload: list[dict] = []
+        for (phone_key, name_key), group_rows in identity_groups.items():
+            shop_keys = {
+                (
+                    str(item.get("shop_id") or ""),
+                    int(item["backend_shop_ref_id"]) if item.get("backend_shop_ref_id") is not None else None,
+                )
+                for item in group_rows
+            }
+            if len(group_rows) > 1 and len(shop_keys) > 1:
+                duplicate_groups_payload.append(
+                    {
+                        "normalized_phone": phone_key,
+                        "normalized_name": name_key,
+                        "shop_count": len(shop_keys),
+                        "client_count": len(group_rows),
+                        "clients": [
+                            {
+                                "client_id": item.get("client_id"),
+                                "backend_client_id": item.get("backend_client_id"),
+                                "shop_id": item.get("shop_id"),
+                                "backend_shop_ref_id": item.get("backend_shop_ref_id"),
+                                "name": item.get("name") or item.get("client_name"),
+                                "phone": item.get("phone"),
+                            }
+                            for item in group_rows
+                        ],
+                    }
+                )
+
+        stats.duplicate_identity_group_count = len(duplicate_groups_payload)
+        stats.duplicate_identity_client_count = sum(int(item.get("client_count") or 0) for item in duplicate_groups_payload)
+        report["duplicate_identity_groups"] = duplicate_groups_payload
+
+        result_updates_applied = 0
+        detail_updates_applied = 0
+        orphan_result_ids: list[int] = []
+        inconsistent_result_ids: list[int] = []
+        resolved_backend_client_by_result_id: dict[int, int | None] = {}
+
+        result_rows = list(
+            LegacyClientResult.objects.all().values(
+                "result_id",
+                "client_id",
+                "backend_client_ref_id",
+                "backend_admin_ref_id",
+            )
+        )
+        stats.result_count = len(result_rows)
+
+        for row in result_rows:
+            result_id = int(row.get("result_id"))
+            legacy_client_id = str(row.get("client_id") or "").strip()
+            backend_client_ref_id = row.get("backend_client_ref_id")
+
+            client_from_backend = (
+                by_backend_client_id.get(int(backend_client_ref_id))
+                if backend_client_ref_id is not None
+                else None
+            )
+            client_from_legacy = by_legacy_client_id.get(legacy_client_id) if legacy_client_id else None
+
+            if client_from_backend is None and client_from_legacy is None:
+                stats.orphan_result_count += 1
+                orphan_result_ids.append(result_id)
+                resolved_backend_client_by_result_id[result_id] = None
+                continue
+
+            if (
+                client_from_backend is not None
+                and client_from_legacy is not None
+                and int(client_from_backend.get("backend_client_id"))
+                != int(client_from_legacy.get("backend_client_id"))
+            ):
+                stats.inconsistent_result_ref_count += 1
+                inconsistent_result_ids.append(result_id)
+                resolved_backend_client_by_result_id[result_id] = int(client_from_backend.get("backend_client_id"))
+                continue
+
+            resolved_client = client_from_backend or client_from_legacy
+            resolved_backend_client_id = (
+                int(resolved_client.get("backend_client_id"))
+                if resolved_client and resolved_client.get("backend_client_id") is not None
+                else None
+            )
+            resolved_legacy_client_id = str(resolved_client.get("client_id") or "") if resolved_client else ""
+            resolved_backend_shop_ref_id = (
+                int(resolved_client.get("backend_shop_ref_id"))
+                if resolved_client and resolved_client.get("backend_shop_ref_id") is not None
+                else None
+            )
+            resolved_backend_client_by_result_id[result_id] = resolved_backend_client_id
+
+            update_fields: dict[str, object] = {}
+
+            if backend_client_ref_id is None and resolved_backend_client_id is not None:
+                stats.fix_result_backend_client_ref_count += 1
+                update_fields["backend_client_ref_id"] = resolved_backend_client_id
+
+            if not legacy_client_id and resolved_legacy_client_id:
+                stats.fix_result_legacy_client_ref_count += 1
+                update_fields["client_id"] = resolved_legacy_client_id
+
+            current_backend_admin_ref = row.get("backend_admin_ref_id")
+            if (
+                resolved_backend_shop_ref_id is not None
+                and current_backend_admin_ref is not None
+                and int(current_backend_admin_ref) != int(resolved_backend_shop_ref_id)
+            ):
+                stats.fix_result_admin_scope_ref_count += 1
+                update_fields["backend_admin_ref_id"] = resolved_backend_shop_ref_id
+            elif resolved_backend_shop_ref_id is not None and current_backend_admin_ref is None:
+                stats.fix_result_admin_scope_ref_count += 1
+                update_fields["backend_admin_ref_id"] = resolved_backend_shop_ref_id
+
+            if apply_changes and update_fields:
+                LegacyClientResult.objects.filter(result_id=result_id).update(**update_fields)
+                result_updates_applied += 1
+
+        detail_rows = list(
+            LegacyClientResultDetail.objects.all().values(
+                "detail_id",
+                "result_id",
+                "backend_client_ref_id",
+            )
+        )
+        stats.detail_count = len(detail_rows)
+        for row in detail_rows:
+            result_id = int(row.get("result_id"))
+            detail_id = int(row.get("detail_id"))
+            current_backend_client_ref_id = row.get("backend_client_ref_id")
+            expected_backend_client_ref_id = resolved_backend_client_by_result_id.get(result_id)
+            if expected_backend_client_ref_id is None:
+                continue
+
+            if current_backend_client_ref_id is None:
+                stats.fix_detail_backend_client_ref_count += 1
+                if apply_changes:
+                    LegacyClientResultDetail.objects.filter(detail_id=detail_id).update(
+                        backend_client_ref_id=expected_backend_client_ref_id
+                    )
+                    detail_updates_applied += 1
+                continue
+
+            if int(current_backend_client_ref_id) != int(expected_backend_client_ref_id):
+                stats.fix_detail_backend_client_ref_count += 1
+                if apply_changes:
+                    LegacyClientResultDetail.objects.filter(detail_id=detail_id).update(
+                        backend_client_ref_id=expected_backend_client_ref_id
+                    )
+                    detail_updates_applied += 1
+
+        report["orphan_result_ids"] = orphan_result_ids[:100]
+        report["inconsistent_result_ids"] = inconsistent_result_ids[:100]
+        report["stats"] = stats.__dict__
+        report["applied"] = {
+            "result_rows_updated": result_updates_applied,
+            "detail_rows_updated": detail_updates_applied,
+        }
+
+        if as_json:
+            self.stdout.write(json.dumps(report, ensure_ascii=False, indent=2))
+            return
+
+        mode_label = "APPLY" if apply_changes else "DRY-RUN"
+        self.stdout.write(self.style.SUCCESS(f"[{mode_label}] client/history scope audit"))
+        self.stdout.write(f"- clients: {stats.client_count}")
+        self.stdout.write(f"- results: {stats.result_count}")
+        self.stdout.write(f"- details: {stats.detail_count}")
+        self.stdout.write(f"- duplicate identity groups (cross-shop): {stats.duplicate_identity_group_count}")
+        self.stdout.write(f"- duplicate identity clients (cross-shop): {stats.duplicate_identity_client_count}")
+        self.stdout.write(f"- orphan results: {stats.orphan_result_count}")
+        self.stdout.write(f"- inconsistent result refs: {stats.inconsistent_result_ref_count}")
+        self.stdout.write(
+            f"- fix candidates: result.backend_client_ref={stats.fix_result_backend_client_ref_count}, "
+            f"result.client_id={stats.fix_result_legacy_client_ref_count}, "
+            f"result.backend_admin_ref={stats.fix_result_admin_scope_ref_count}, "
+            f"detail.backend_client_ref={stats.fix_detail_backend_client_ref_count}"
+        )
+        self.stdout.write(
+            f"- applied updates: result={result_updates_applied}, detail={detail_updates_applied}"
+        )

--- a/app/services/model_team_bridge.py
+++ b/app/services/model_team_bridge.py
@@ -814,7 +814,18 @@ def upsert_client_record(*, phone: str, name: str, gender: str | None = None, ag
     normalized_name = _normalize_person_name(name)
     created_at = timezone.now()
     row = None
-    for candidate in LegacyClient.objects.filter(phone=normalized_phone).order_by("-backend_client_id", "client_id"):
+    candidate_queryset = LegacyClient.objects.filter(phone=normalized_phone)
+    backend_shop_id = getattr(shop, "id", None)
+    legacy_shop_id = get_legacy_admin_id(admin=shop) if shop is not None else None
+    if backend_shop_id is not None or legacy_shop_id:
+        shop_scope = Q()
+        if backend_shop_id is not None:
+            shop_scope |= Q(backend_shop_ref_id=backend_shop_id)
+        if legacy_shop_id:
+            shop_scope |= Q(shop_id=legacy_shop_id)
+        candidate_queryset = candidate_queryset.filter(shop_scope)
+
+    for candidate in candidate_queryset.order_by("-backend_client_id", "client_id"):
         candidate_name = _normalize_person_name(getattr(candidate, "name", None) or getattr(candidate, "client_name", None))
         if candidate_name == normalized_name:
             row = candidate
@@ -1783,6 +1794,22 @@ def get_legacy_active_consultation_count(
         if client_key:
             active_clients.add(client_key)
     return len(active_clients)
+
+
+def has_legacy_chosen_consultation(*, client: Client) -> bool:
+    if not _has_columns("client_result", LEGACY_RESULT_MODEL_COLUMNS):
+        return False
+    result_queryset = _legacy_result_queryset(client=client)
+    if result_queryset.filter(selected_hairstyle_id__gt=0).exists():
+        return True
+    if _has_columns("client_result_detail", LEGACY_RESULT_DETAIL_MODEL_COLUMNS):
+        result_ids = list(result_queryset.values_list("result_id", flat=True))
+        if result_ids:
+            return LegacyClientResultDetail.objects.filter(
+                result_id__in=result_ids,
+                is_chosen=True,
+            ).exists()
+    return False
 
 
 def get_legacy_confirmed_selection_items(

--- a/choi_sample/review/report_20260422_PM_v2.md
+++ b/choi_sample/review/report_20260422_PM_v2.md
@@ -1,0 +1,42 @@
+# MirrAI 작업 리포트 (2026-04-22 PM v2)
+
+## 1) 작업 목적
+- 고객 재방문 시 `menu-resume-wrap` 단계 표기를 실제 진행 상태와 일치시키기
+- 추천 카드 제목/설명에 남아 있는 영문 스타일 명칭을 한글로 통일하기
+- 고객 이력 스코프 점검용 커맨드 추가로 데이터 검증 기반 확보
+
+## 2) 반영 파일
+- `app/front_views.py`
+- `app/services/model_team_bridge.py`
+- `templates/customer/result.html`
+- `app/management/commands/audit_client_history_scope.py`
+
+## 3) 주요 변경 내용
+### A. 고객 메뉴 재진입 단계 판정 보정
+- `client_menu_page`에서 상담 완료 여부를 최근 배치 결과만 보지 않고 레거시 전체 이력 기준으로 판정하도록 수정
+- 촬영 시점(`capture_at`)과 설문 시점(`survey_at`)을 비교해, 촬영 이후 설문 미완료 케이스가 `설문 완료`로 잘못 보이는 문제 보정
+- 첫 방문(진행 이력 없음)과 상담 완료 이력 존재 시 `resume` 블록 숨김 처리 유지
+
+### B. 고객 매칭/상담 완료 이력 판정 강화
+- `upsert_client_record`에서 전화번호 단일 조건이 아닌 이름+전화번호(매장 스코프 포함) 기반으로 기존 고객 탐색 강화
+- `has_legacy_chosen_consultation` 헬퍼 추가:
+  - `client_result.selected_hairstyle_id > 0`
+  - 또는 `client_result_detail.is_chosen = True`
+  - 두 경로 모두 확인하여 상담 완료 이력 판정 정확도 개선
+
+### C. 추천 카드 한글화 확대
+- `templates/customer/result.html`의 `EN_TO_KO_PHRASES` 사전 확장
+- 잔여 영문 토큰(`side-parted`, `c-curl`, `s-curl`, `textured`, `airy`, `short`, `medium`, `full`, `long`, `wave`, `flow`, `curl`, `hush`, `mini`) 한글 치환 추가
+- `part` 치환 후 `파트ed` 같은 혼합 문자열이 남지 않도록 후처리 보강
+
+### D. 운영 점검 커맨드 추가
+- `audit_client_history_scope` 커맨드 추가
+- 고객 이력 스코프 이상 데이터 탐지/보정에 활용 가능
+
+## 4) 검증
+- `python manage.py check`
+  - 결과: `System check identified no issues (0 silenced).`
+
+## 5) 영향도
+- UI 출력 문구와 메뉴 단계 계산 로직의 정확도 개선 중심 변경
+- 기존 인증/세션 핵심 플로우를 직접 변경하지 않고, 단계 판정 및 텍스트 가공 계층에서 최소 영향 방식으로 반영

--- a/templates/customer/result.html
+++ b/templates/customer/result.html
@@ -397,12 +397,31 @@
     const EN_TO_KO_PHRASES = [
       ['clean crop two-block', '깔끔한 크롭 투블럭'],
       ['tapered slick part', '테이퍼드 슬릭 파트'],
+      ['sleek mini', '슬릭 미니'],
+      ['side-parted', '사이드 파트'],
+      ['side parted', '사이드 파트'],
+      ['c-curl', '씨컬'],
+      ['c curl', '씨컬'],
+      ['s-curl', '에스컬'],
+      ['s curl', '에스컬'],
       ['side part', '사이드 파트 컷'],
       ['down perm', '다운펌'],
+      ['textured', '텍스처드'],
+      ['airy', '에어리'],
+      ['short', '숏'],
+      ['medium', '미디엄'],
+      ['full', '풀'],
+      ['long', '롱'],
+      ['wave', '웨이브'],
+      ['flow', '플로우'],
+      ['curl', '컬'],
+      ['hush', '허쉬'],
       ['down', '다운'],
       ['two-block', '투블럭'],
       ['crop', '크롭'],
       ['slick', '슬릭'],
+      ['mini', '미니'],
+      ['parted', '파트'],
       ['tapered', '테이퍼드'],
       ['part', '파트'],
       ['inverted triangle', '역삼각형'],
@@ -453,6 +472,7 @@
         text = text.replace(new RegExp(escaped, 'gi'), ko);
       });
       return text
+        .replace(/파트ed/gi, '파트')
         .replace(/\|/g, ' | ')
         .replace(/\s{2,}/g, ' ')
         .trim();


### PR DESCRIPTION
# MirrAI 작업 리포트 (2026-04-22 PM v2)

## 1) 작업 목적

- 고객 재방문 시 `menu-resume-wrap` 단계 표기를 실제 진행 상태와 일치시키기
- 추천 카드 제목/설명에 남아 있는 영문 스타일 명칭을 한글로 통일하기
- 고객 이력 스코프 점검용 커맨드 추가로 데이터 검증 기반 확보

## 2) 반영 파일

- `app/front_views.py`
- `app/services/model_team_bridge.py`
- `templates/customer/result.html`
- `app/management/commands/audit_client_history_scope.py`

## 3) 주요 변경 내용

### A. 고객 메뉴 재진입 단계 판정 보정

- `client_menu_page`에서 상담 완료 여부를 최근 배치 결과만 보지 않고 레거시 전체 이력 기준으로 판정하도록 수정
- 촬영 시점(`capture_at`)과 설문 시점(`survey_at`)을 비교해, 촬영 이후 설문 미완료 케이스가 `설문 완료`로 잘못 보이는 문제 보정
- 첫 방문(진행 이력 없음)과 상담 완료 이력 존재 시 `resume` 블록 숨김 처리 유지

### B. 고객 매칭/상담 완료 이력 판정 강화

- `upsert_client_record`에서 전화번호 단일 조건이 아닌 이름+전화번호(매장 스코프 포함) 기반으로 기존 고객 탐색 강화
- `has_legacy_chosen_consultation` 헬퍼 추가:
  - `client_result.selected_hairstyle_id > 0`
  - 또는 `client_result_detail.is_chosen = True`
  - 두 경로 모두 확인하여 상담 완료 이력 판정 정확도 개선

### C. 추천 카드 한글화 확대

- `templates/customer/result.html`의 `EN_TO_KO_PHRASES` 사전 확장
- 잔여 영문 토큰(`side-parted`, `c-curl`, `s-curl`, `textured`, `airy`, `short`, `medium`, `full`, `long`, `wave`, `flow`, `curl`, `hush`, `mini`) 한글 치환 추가
- `part` 치환 후 `파트ed` 같은 혼합 문자열이 남지 않도록 후처리 보강

### D. 운영 점검 커맨드 추가

- `audit_client_history_scope` 커맨드 추가
- 고객 이력 스코프 이상 데이터 탐지/보정에 활용 가능

## 4) 검증

- `python manage.py check`
  - 결과: `System check identified no issues (0 silenced).`

## 5) 영향도

- UI 출력 문구와 메뉴 단계 계산 로직의 정확도 개선 중심 변경
- 기존 인증/세션 핵심 플로우를 직접 변경하지 않고, 단계 판정 및 텍스트 가공 계층에서 최소 영향 방식으로 반영