### PR TITLE
feat: refine partner dashboard statuses and admin UI copy

### DIFF
--- a/app/api/v1/admin_services.py
+++ b/app/api/v1/admin_services.py
@@ -24,7 +24,14 @@ from app.api.v1.services_django import (
     get_latest_survey,
     serialize_recommendation_row,
 )
-from app.models_model_team import LegacyClient, LegacyClientResult, LegacyDesigner, LegacyHairstyle
+from app.models_model_team import (
+    LegacyClient,
+    LegacyClientAnalysis,
+    LegacyClientResult,
+    LegacyClientSurvey,
+    LegacyDesigner,
+    LegacyHairstyle,
+)
 from app.services.age_profile import build_client_age_profile
 from app.services.ai_facade import get_ai_health
 from app.services.model_team_bridge import (
@@ -1600,6 +1607,39 @@ def get_all_clients(*, query: str = "", admin: "AdminAccount | None" = None, des
     legacy_active_items = get_legacy_active_consultation_items(admin=admin, designer=designer) or []
     legacy_active_by_client = _build_active_consultation_client_map(legacy_active_items)
     legacy_visit_summary_by_client = get_legacy_client_visit_summary_map(admin=admin, designer=designer)
+    legacy_client_ids = {
+        str(get_legacy_client_id(client=client) or "").strip()
+        for client in clients
+    }
+    legacy_client_ids.discard("")
+
+    survey_completed_keys: set[str] = set()
+    photo_captured_keys: set[str] = set()
+    consultation_requested_keys: set[str] = set()
+
+    if legacy_client_ids:
+        survey_completed_keys = {
+            str(value).strip()
+            for value in LegacyClientSurvey.objects.filter(client_id__in=legacy_client_ids).values_list("client_id", flat=True)
+            if value
+        }
+        photo_captured_keys = {
+            str(value).strip()
+            for value in LegacyClientAnalysis.objects.filter(client_id__in=legacy_client_ids).values_list("client_id", flat=True)
+            if value
+        }
+        confirmed_items = get_legacy_confirmed_selection_items(
+            admin=admin,
+            designer=designer,
+            compact=True,
+        ) or []
+        for confirmed in confirmed_items:
+            backend_client_key = str(confirmed.get("client_id") or "").strip()
+            legacy_client_key = str(confirmed.get("legacy_client_id") or "").strip()
+            if backend_client_key:
+                consultation_requested_keys.add(backend_client_key)
+            if legacy_client_key:
+                consultation_requested_keys.add(legacy_client_key)
 
     items = []
     for client in clients:
@@ -1639,6 +1679,12 @@ def get_all_clients(*, query: str = "", admin: "AdminAccount | None" = None, des
                 "has_active_consultation": bool(legacy_active and legacy_active.get("is_active")),
                 "session_active": bool(legacy_active and legacy_active.get("is_active")),
                 "can_write_designer_diagnosis": bool(legacy_active and legacy_active.get("is_active")),
+                "has_survey_completed": bool(legacy_client_id and legacy_client_id in survey_completed_keys),
+                "has_photo_captured": bool(legacy_client_id and legacy_client_id in photo_captured_keys),
+                "has_consultation_requested": bool(
+                    (backend_client_id and backend_client_id in consultation_requested_keys)
+                    or (legacy_client_id and legacy_client_id in consultation_requested_keys)
+                ),
             }
         )
     payload = {"status": "ready", "items": items}

--- a/app/api/v1/admin_views.py
+++ b/app/api/v1/admin_views.py
@@ -333,6 +333,9 @@ class LegacyAllClientsView(CompatEnvelopeAPIView):
                 "has_active_consultation": item.get("has_active_consultation", False),
                 "session_active": item.get("session_active", False),
                 "can_write_designer_diagnosis": item.get("can_write_designer_diagnosis", False),
+                "has_survey_completed": item.get("has_survey_completed", False),
+                "has_photo_captured": item.get("has_photo_captured", False),
+                "has_consultation_requested": item.get("has_consultation_requested", False),
             }
             for item in payload["items"]
         ]

--- a/templates/admin/customer_detail.html
+++ b/templates/admin/customer_detail.html
@@ -785,6 +785,94 @@
       return `${Math.round(numeric)}%`;
     }
 
+    function localizeStyleName(rawName) {
+      const original = String(rawName || '').trim();
+      if (!original) {
+        return '선택 스타일';
+      }
+
+      const normalized = original.toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+
+      // 전체 스타일명이 자주 쓰는 조합이면 우선 치환
+      const exactMap = {
+        'french bob': '프렌치 보브',
+        'hush cut': '허쉬 컷',
+        'wolf cut': '울프 컷',
+        'pixie cut': '픽시 컷',
+        'two block': '투블럭',
+        'two block cut': '투블럭 컷',
+        'clean crop two block': '클린 크롭 투블럭',
+        'side parted lob': '사이드 파티드 롱보브',
+        'sleek mini bob': '슬릭 미니 보브',
+        'soft layered cut': '소프트 레이어드 컷',
+        'shaggy midi cut': '샤기 미디 컷',
+        'soft down perm': '소프트 다운 펌',
+        'down perm': '다운 펌'
+      };
+      if (exactMap[normalized]) {
+        return exactMap[normalized];
+      }
+
+      const tokenMap = {
+        short: '숏',
+        medium: '미디엄',
+        midi: '미디',
+        long: '롱',
+        mini: '미니',
+        side: '사이드',
+        parted: '파티드',
+        part: '파트',
+        sleek: '슬릭',
+        soft: '소프트',
+        natural: '내추럴',
+        volume: '볼륨',
+        wave: '웨이브',
+        wavy: '웨이비',
+        layered: '레이어드',
+        layer: '레이어',
+        shaggy: '샤기',
+        hush: '허쉬',
+        wolf: '울프',
+        pixie: '픽시',
+        crop: '크롭',
+        bob: '보브',
+        lob: '롱보브',
+        down: '다운',
+        up: '업',
+        perm: '펌',
+        cut: '컷',
+        style: '스타일',
+        bang: '뱅',
+        see: '씨',
+        c: 'C',
+        s: 'S'
+      };
+
+      // 사전에 없는 영문 토큰도 한글 표기로 강제 변환
+      const letterMap = {
+        a: '에이', b: '비', c: '씨', d: '디', e: '이', f: '에프', g: '지', h: '에이치',
+        i: '아이', j: '제이', k: '케이', l: '엘', m: '엠', n: '엔', o: '오', p: '피',
+        q: '큐', r: '알', s: '에스', t: '티', u: '유', v: '브이', w: '더블유', x: '엑스',
+        y: '와이', z: '지'
+      };
+      function spellEnglishToken(token) {
+        return token
+          .toLowerCase()
+          .split('')
+          .map((ch) => letterMap[ch] || ch)
+          .join('');
+      }
+
+      return original
+        .replace(/[_-]+/g, ' ')
+        .replace(/[A-Za-z]+/g, (matched) => {
+          const lower = matched.toLowerCase();
+          return tokenMap[lower] || spellEnglishToken(lower);
+        })
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
     function getFaceShapeLabel(value) {
       const normalized = String(value || '').trim().toLowerCase();
       if (!normalized) {
@@ -1588,7 +1676,8 @@
         return '';
       }
 
-      const styleName = activeConsultation.selected_style_name || '선택 스타일';
+      const styleNameRaw = activeConsultation.selected_style_name || '선택 스타일';
+      const styleName = localizeStyleName(styleNameRaw);
       const imageUrl = String(activeConsultation.selected_style_image_url || '').trim();
       const scoreText = formatScore(activeConsultation.selected_style_score);
       const createdAt = formatDate(activeConsultation.created_at);

--- a/templates/admin/designer_management.html
+++ b/templates/admin/designer_management.html
@@ -60,6 +60,30 @@
     color: #b42318;
     border: 1px solid #fecaca;
   }
+
+  /* 대시보드 페이지의 back-btn 스타일과 동일 */
+  .back-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 600;
+    padding: 8px 16px;
+    border-radius: 10px;
+    border: 1.5px solid var(--line);
+    background: #fff;
+    transition: all 0.2s ease;
+    cursor: pointer;
+  }
+
+  .back-btn:hover {
+    color: var(--bg-dark);
+    border-color: var(--bg-dark);
+    background: #fcfcfc;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  }
 </style>
 {% endblock %}
 
@@ -81,6 +105,10 @@
       <div style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
         <a href="{% url 'partner_designer_signup' %}" class="session-btn" style="height: 32px !important; padding: 0 14px !important; font-size: 13px !important; border-radius: 999px !important; background: var(--bg-dark) !important; color: #fff !important; border: none !important; font-weight: 700; display: inline-flex; align-items: center; text-decoration: none;">신규 디자이너 생성</a>
         <button onclick="openDeletePinModal()" class="session-btn" style="height: 32px !important; padding: 0 14px !important; font-size: 13px !important; border-radius: 999px !important; background: #fff !important; color: var(--text-secondary) !important; border: 1.5px solid var(--line) !important; font-weight: 600; cursor: pointer; display: inline-flex; align-items: center; transition: all 0.2s ease;">기존 디자이너 삭제</button>
+        <a href="{% url 'partner_dashboard' %}" class="back-btn">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
+          대시보드
+        </a>
       </div>
     </div>
 
@@ -203,9 +231,9 @@
       targetDesignerId = '';
       targetDesignerName = '';
       currentPin = '';
-      if (pinHeaderTitle) pinHeaderTitle.textContent = '??? ??';
-      if (pinHeaderDesc) pinHeaderDesc.textContent = '???? ??? ?? ??? ???(PIN)? ??? ???.';
-      if (pinSubmitBtn) pinSubmitBtn.textContent = '??';
+      if (pinHeaderTitle) pinHeaderTitle.textContent = '관리자 인증';
+      if (pinHeaderDesc) pinHeaderDesc.textContent = '디자이너 삭제를 위해 관리자 보안키(PIN)를 입력해 주세요.';
+      if (pinSubmitBtn) pinSubmitBtn.textContent = '확인';
       updatePinDots();
       if (pinModal) pinModal.classList.add('active');
     };
@@ -268,11 +296,11 @@
           });
           const data = await response.json();
           if (data.status === 'success') {
-            window.alert(data.message || '???? PIN ??? ???????.');
+            window.alert(data.message || '디자이너 잠금이 해제되었습니다.');
             closeAdminPinModal();
             clearPin();
           } else {
-            window.alert(data.message || '?? ??? ??????.');
+            window.alert(data.message || '잠금 해제에 실패했습니다.');
             clearPin();
           }
           return;
@@ -287,11 +315,11 @@
         if (data.status === 'success') {
           window.location.href = "{% url 'partner_designer_delete' %}";
         } else {
-          window.alert(data.message || '????? ???? ????.');
+          window.alert(data.message || '관리자 인증에 실패했습니다.');
           clearPin();
         }
       } catch (error) {
-        window.alert('?? ?? ? ??? ??????.');
+        window.alert('요청 처리 중 오류가 발생했습니다.');
       }
     };
 

--- a/templates/admin/index.html
+++ b/templates/admin/index.html
@@ -206,14 +206,14 @@
           <button id="searchBtn" class="btn btn-dark" style="padding: 0 24px; height: 48px; border-radius: 12px;">검색</button>
         </div>
         <div class="table-container">
-          <table style="width: 100%; border-collapse: collapse;">
+          <table style="width: 100%; border-collapse: collapse; table-layout: fixed;">
             <thead>
-              <tr style="border-bottom: 2px solid var(--line); text-align: left;">
-                <th style="padding: 12px 20px; font-size: 13px; color: var(--text-secondary);">고객명</th>
-                <th style="padding: 12px 20px; font-size: 13px; color: var(--text-secondary);">디자이너</th>
-                <th style="padding: 12px 20px; font-size: 13px; color: var(--text-secondary);">최근 방문</th>
-                <th style="padding: 12px 20px; font-size: 13px; color: var(--text-secondary);">총 방문수</th>
-                <th style="padding: 12px 20px;"></th>
+              <tr style="border-bottom: 2px solid var(--line); text-align: center;">
+                <th style="width: 20%; padding: 12px 20px; font-size: 13px; color: var(--text-secondary); text-align: center;">고객명</th>
+                <th style="width: 20%; padding: 12px 20px; font-size: 13px; color: var(--text-secondary); text-align: center;">디자이너</th>
+                <th style="width: 20%; padding: 12px 20px; font-size: 13px; color: var(--text-secondary); text-align: center;">최근 방문</th>
+                <th style="width: 20%; padding: 12px 20px; font-size: 13px; color: var(--text-secondary); text-align: center;">총 방문수</th>
+                <th style="width: 20%; padding: 12px 20px; font-size: 13px; color: var(--text-secondary); text-align: center;">고객카드</th>
               </tr>
             </thead>
             <tbody id="customerListBody"></tbody>
@@ -708,9 +708,21 @@
           visitText = diffDays === 0 ? '오늘' : `${diffDays}일 전`;
         }
         const sessionActive = Boolean(c.session_active || c.has_active_consultation);
-        const sessionBadge = sessionActive
-          ? '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(21, 128, 61, 0.12); color:#166534; font-size:11px; font-weight:700;">세션 진행 중</span>'
-          : '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(71, 85, 105, 0.12); color:#475569; font-size:11px; font-weight:700;">세션 없음</span>';
+        const hasConsultationRequested = Boolean(c.has_consultation_requested);
+        const hasSurveyCompleted = Boolean(c.has_survey_completed);
+        const hasPhotoCaptured = Boolean(c.has_photo_captured);
+
+        let sessionBadge = '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(71, 85, 105, 0.12); color:#475569; font-size:11px; font-weight:700;">사진 촬영 전</span>';
+
+        if (hasSurveyCompleted && hasPhotoCaptured) {
+          sessionBadge = '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(180, 83, 9, 0.12); color:#92400e; font-size:11px; font-weight:700;">취향 설문 완료</span>';
+        }
+        if (hasConsultationRequested) {
+          sessionBadge = '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(30, 64, 175, 0.12); color:#1e40af; font-size:11px; font-weight:700;">상담 신청 완료</span>';
+        }
+        if (sessionActive) {
+          sessionBadge = '<span style="display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; background: rgba(21, 128, 61, 0.12); color:#166534; font-size:11px; font-weight:700;">상담 진행 중</span>';
+        }
 
         let detailAction = "";
 
@@ -723,16 +735,18 @@
 
         return `
           <tr style="border-bottom: 1px solid var(--line);">
-            <td style="padding: 16px 20px;"><span style="font-weight: 700; color: var(--bg-dark);">${c.name}</span></td>
             <td style="padding: 16px 20px; color: var(--text-primary); font-size: 14px;">
               <div style="display:flex; flex-direction:column; gap:8px;">
-                <span>${c.designer_name || '미지정'}</span>
+                <span style="font-weight: 700; color: var(--bg-dark);">${c.name}</span>
                 ${sessionBadge}
               </div>
             </td>
-            <td style="padding: 16px 20px; color: var(--text-secondary); font-size: 13px;">${visitText}</td>
-            <td style="padding: 16px 20px; color: var(--text-secondary); font-size: 13px;">${c.visit_count || '1'}회</td>
-            <td style="padding: 16px 20px; text-align: right;">
+            <td style="padding: 16px 20px; color: var(--text-primary); font-size: 14px; text-align: center;">
+              <span>${c.designer_name || '미지정'}</span>
+            </td>
+            <td style="padding: 16px 20px; color: var(--text-secondary); font-size: 13px; text-align: center;">${visitText}</td>
+            <td style="padding: 16px 20px; color: var(--text-secondary); font-size: 13px; text-align: center;">${c.visit_count || '1'}회</td>
+            <td style="padding: 16px 20px; text-align: center;">
               <button onclick="${detailAction}" style="border: none; cursor: pointer; font-size: 12px; padding: 6px 14px; background: var(--bg-dark); border-radius: 20px; color: #fff; font-weight: 600;">상세보기</button>
             </td>
           </tr>

--- a/templates/customer/trend.html
+++ b/templates/customer/trend.html
@@ -16,14 +16,6 @@
     gap: 24px;
   }
 
-  .trend-feed-header {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 16px;
-    flex-wrap: wrap;
-  }
-
   .trend-slider-shell {
     overflow: hidden;
   }
@@ -206,13 +198,6 @@
 
 {% block content %}
 <div class="trend-feed" style="max-width: 1200px; margin: 0 auto;">
-  <div class="trend-feed-header">
-    <a href="{{ back_url|default:'#' }}" class="session-btn" style="height: 40px; background: #fff;">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="margin-right: 4px;"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
-      메인으로
-    </a>
-  </div>
-
   <div id="trendLoading" class="panel" style="padding: 28px; text-align: center;">최신 트렌드를 불러오는 중입니다...</div>
 
   <div id="trendSliderShell" class="trend-slider-shell" style="display: none;">


### PR DESCRIPTION
# 작업 보고서 (2026-04-23)

- 브랜치: design/ui-0423

## 반영 파일
- app/api/v1/admin_services.py
- app/api/v1/admin_views.py
- 	emplates/admin/customer_detail.html
- 	emplates/admin/designer_management.html
- 	emplates/admin/index.html
- 	emplates/customer/trend.html

## 주요 변경 요약
- 파트너 대시보드 고객 상태 배지 단계형 표시 적용
- 고객 목록 상태 계산 로직 최적화(배치 조회)
- 관리자/디자이너 화면 UI 문구 및 버튼/정렬 개선
- 트렌드 페이지 헤더 영역 정리
